### PR TITLE
Dice tweaks (#25)

### DIFF
--- a/src/sage-dice/common.ts
+++ b/src/sage-dice/common.ts
@@ -10,28 +10,31 @@ export type TGameType = "NONE" | "PF" | "PF1" | "PF1E" | "PF2" | "PF2E" | "SF" |
 
 export enum GameType {
 	None = 0,
-	/* Pathfinder 1e */
+	/** Pathfinder 1e */
 	PF1e = 11,
-	/* Pathfinder 2e */
+	/** Pathfinder 2e */
 	PF2e = 12,
-	/* Starfinder */
+	/** Starfinder */
 	SF1e = 21,
-	/* Coyote & Crow */
+	/** Coyote & Crow */
 	CnC = 31,
-	/* Dungeons and Dragons 5e */
+	/** Dungeons and Dragons 5e */
 	DnD5e = 55,
-	/* Quest */
+	/** Essence 20 */
+	E20 = 41,
+	/** Quest */
 	Quest = 71
 }
 
 const GameTypeMap = {
 	"NONE":GameType.None,
-	"5E":GameType.DnD5e, "DND5E":GameType.DnD5e,
 	"PF":GameType.PF1e, "PF1":GameType.PF1e, "PF1E":GameType.PF1e,
 	"PF2":GameType.PF2e, "PF2E":GameType.PF2e,
 	"SF":GameType.SF1e, "SF1":GameType.SF1e, "SF1E":GameType.SF1e,
-	"QUEST":GameType.Quest,
-	"CNC":GameType.CnC
+	"CNC":GameType.CnC,
+	"5E":GameType.DnD5e, "DND5E":GameType.DnD5e,
+	"E20":GameType.E20, "ESS20":GameType.E20, "ESSENCE20":GameType.E20,
+	"QUEST":GameType.Quest
 };
 
 export function parseGameType(gameType: string, defaultGameType?: GameType): GameType | undefined {
@@ -44,7 +47,7 @@ export function parseGameType(gameType: string, defaultGameType?: GameType): Gam
 
 export type TDiceOutputType = keyof typeof DiceOutputType;
 
-export enum DiceOutputType { XXS = -3, XS = -2, S = -1, M = 0, L = 1, XL = 2, XXL = 3 }
+export enum DiceOutputType { XXS = -3, XS = -2, S = -1, M = 0, L = 1, XL = 2, XXL = 3, ROLLEM = 5 }
 
 export function parseDiceOutputType(outputType: string, defaultOutputType?: DiceOutputType): DiceOutputType | undefined {
 	return DiceOutputType[<TDiceOutputType>String(outputType).toUpperCase()] ?? defaultOutputType;
@@ -59,6 +62,7 @@ export enum CritMethodType { Unknown = 0, TimesTwo = 1, RollTwice = 2, AddMax = 
 type TTypedMap<T> = { [key: string]: T; };
 
 const CritMethodTypeMap: TTypedMap<TTypedMap<CritMethodType>> = {
+	"DND5E":{ "TIMESTWO":CritMethodType.TimesTwo, "ROLLTWICE":CritMethodType.RollTwice, "ADDMAX":CritMethodType.AddMax },
 	"PF2E":{ "TIMESTWO":CritMethodType.TimesTwo, "ROLLTWICE":CritMethodType.RollTwice, "ADDMAX":CritMethodType.AddMax }
 };
 
@@ -71,7 +75,7 @@ export function parseCritMethodType(gameType: GameType | undefined, critMethod: 
 }
 
 export function getCritMethodRegex(gameType: GameType | undefined): RegExp | null {
-	if (gameType === GameType.PF2e) {
+	if ([GameType.DnD5e, GameType.PF2e].includes(gameType!)) {
 		return /^(timestwo|rolltwice|addmax)?/i;
 	}
 	return null;

--- a/src/sage-dice/dice/base/index.ts
+++ b/src/sage-dice/dice/base/index.ts
@@ -1,7 +1,10 @@
 //#region imports
 
 import type { Optional, OrNull, OrUndefined, TParsers, TSortResult, TToken } from "../../../sage-utils";
-import utils from "../../../sage-utils";
+import { sortAscending } from "../../../sage-utils/utils/ArrayUtils/Sort";
+import { toJSON } from "../../../sage-utils/utils/ClassUtils";
+import { cleanWhitespace, dequote, Tokenizer } from "../../../sage-utils/utils/StringUtils";
+import { generate } from "../../../sage-utils/utils/UuidUtils";
 import type {
 	IDiceBase,
 	IRollBase,
@@ -23,19 +26,8 @@ import {
 	sumDropKeep, TestType, UNICODE_LEFT_ARROW
 } from "../../common";
 import type {
-	TDiceRoll,
-	TDicePartRoll,
-	TDicePartCoreArgs,
-	TDicePart,
-	DicePartRollCore,
-	DiceCore,
-	TDice,
-	DiceRollCore,
-	DiceGroupCore,
-	TDiceGroupRoll,
-	TDiceGroup,
-	DiceGroupRollCore,
-	DicePartCore
+	DiceCore, DiceGroupCore, DiceGroupRollCore,
+	DicePartCore, DicePartRollCore, DiceRollCore, TDice, TDiceGroup, TDiceGroupRoll, TDicePart, TDicePartCoreArgs, TDicePartRoll, TDiceRoll
 } from "./types";
 
 //#endregion
@@ -76,9 +68,18 @@ function reduceDescriptionToken<T extends DicePartCore>(core: T, token: TToken):
 	return core;
 }
 
-/** Sets the core's .sign, .count, and .sides values from the tokens .matches */
-function reduceDiceToken<T extends DicePartCore>(core: T, token: TToken): T {
-	//TODO: consider imnplementing pf2e.reducePlusMinusToDropKeep for all dice
+export type TReduceSignToDropKeep = {
+	sign: TSign;
+	type: DropKeepType;
+	value: number;
+	alias: string;
+	test: (core: DicePartCore, token: TToken) => boolean;
+};
+/**
+ * Sets the core's .sign, .count, and .sides values from the tokens .matches
+ * If reducePlusMinusToDropKeepData provided, a +2d20/-2d20 roll will be converted to 2d20kh1/2d20kl1 (Fortune/Misfortune; Advantage/Disadvantage)
+ * */
+function reduceDiceToken<T extends DicePartCore>(core: T, token: TToken, reduceSignToDropKeepData?: TReduceSignToDropKeep[]): T {
 	if (token.matches) {
 		core.sign = <TSign>token.matches[0];
 		core.count = +token.matches[1] || 0;
@@ -86,6 +87,11 @@ function reduceDiceToken<T extends DicePartCore>(core: T, token: TToken): T {
 		if (!core.count && core.sides) {
 			core.count = 1;
 		}
+	}
+	const dropKeep = reduceSignToDropKeepData?.find(dropKeepData => dropKeepData.test(core, token));
+	if (dropKeep) {
+		core.dropKeep = dropKeep;
+		delete core.sign;
 	}
 	return core;
 }
@@ -121,9 +127,9 @@ function reduceTestToken<T extends DicePartCore>(core: T, token: TToken): T {
 
 //#endregion
 
-export function reduceTokenToDicePartCore<T extends DicePartCore>(core: T, token: TToken, index: number, tokens: TToken[]): T {
+export function reduceTokenToDicePartCore<T extends DicePartCore>(core: T, token: TToken, index: number, tokens: TToken[], reduceSignToDropKeepData?: TReduceSignToDropKeep[]): T {
 	switch (token.type) {
-		case "dice": return reduceDiceToken(core, token);
+		case "dice": return reduceDiceToken(core, token, reduceSignToDropKeepData);
 		case "dropKeep": return reduceDropKeepToken(core, token, tokens[index - 1]);
 		case "noSort": return reduceNoSortToken(core, token, tokens[index - 1]);
 		case "mod": return reduceModToken(core, token);
@@ -191,12 +197,12 @@ function mapRollAndIndex(sides: number, roll: number, index: number): TRollAndIn
 type TMappedAndSortedRolls = { byIndex:TRollAndIndex[]; byRoll:TRollAndIndex[]; length:number };
 
 function sortRollAndIndex(a: TRollAndIndex, b: TRollAndIndex): TSortResult {
-	const byRoll = utils.ArrayUtils.Sort.number(a.roll, b.roll);
+	const byRoll = sortAscending(a.roll, b.roll);
 	if (byRoll !== 0) {
 		return byRoll;
 	}
 	// The second sort of .index ensures that the first of two equal rolls is on the left so that we properly strike them in order.
-	return utils.ArrayUtils.Sort.number(a.index, b.index);
+	return sortAscending(a.index, b.index);
 }
 
 function mapAndSortRolls(sides: number, rolls: number[]): TMappedAndSortedRolls {
@@ -256,14 +262,15 @@ function mapDicePartRollToString(dicePartRoll: TDicePartRoll, includeSign: boole
 	return dicePartRollOutput.replace(/ +/g, " ").trim();
 }
 
-type TDicePartRollToString = (dicePartRoll: TDicePartRoll, index: number, hideRolls: boolean) => string;
+type TDicePartRollToString = (dicePartRoll: TDicePartRoll, index: number, hideRolls: boolean, rollem: boolean) => string;
 
-function mapDicePartRollToStringWithDice(dicePartRoll: TDicePartRoll, index: number, hideRolls: boolean): string {
+function mapDicePartRollToStringWithDice(dicePartRoll: TDicePartRoll, index: number, hideRolls: boolean, rollem: boolean): string {
 	return mapDicePartRollToString(dicePartRoll, index > 0 || (dicePartRoll.sign !== undefined && dicePartRoll.sign !== "+"), true, true, dpr => {
+		const rollemSpacer = rollem ? " " : "";
 		if (hideRolls && dpr.dice.hasDie) {
-			return ` ||${dicePartRollToString(dpr)}||${dpr.dice.count}d${dpr.dice.sides} `;
+			return ` ||${dicePartRollToString(dpr)}||${rollemSpacer}${dpr.dice.count}d${dpr.dice.sides} `;
 		}
-		return dpr.dice.hasDie ? ` ${dicePartRollToString(dpr)}${dpr.dice.count}d${dpr.dice.sides} ` : ``;
+		return dpr.dice.hasDie ? ` ${dicePartRollToString(dpr)}${rollemSpacer}${dpr.dice.count}d${dpr.dice.sides} ` : ``;
 	});
 }
 
@@ -307,8 +314,10 @@ export class DicePart<T extends DicePartCore, U extends TDicePartRoll> extends H
 		}
 		return this.count;
 	}
-	public get max(): number { return this.adjustedCount * this.sides + this.modifier; }
-	public get min(): number { return this.adjustedCount + this.modifier; }
+	private get biggest(): number { return this.adjustedCount * this.sides + this.modifier; }
+	private get smallest(): number { return this.adjustedCount + this.modifier; }
+	public get max(): number { return this.sign === "-" ? -1 * this.smallest : this.biggest; }
+	public get min(): number { return this.sign === "-" ? -1 * this.biggest : this.smallest; }
 	//#endregion
 
 	//#region flags
@@ -360,7 +369,7 @@ export class DicePart<T extends DicePartCore, U extends TDicePartRoll> extends H
 		return new DicePart({
 			objectType: "DicePart",
 			gameType: GameType.None,
-			id: utils.UuidUtils.generate(),
+			id: generate(),
 
 			count: count ?? 0,
 			description: cleanDescription(description),
@@ -421,8 +430,17 @@ export class DicePartRoll<T extends DicePartRollCore, U extends TDicePart> exten
 	public get hasSecret(): boolean {
 		return this.dice.hasSecret;
 	}
+	/** The raw rolls. */
 	public get rolls(): number[] {
 		return this.core.rolls.slice();
+	}
+	/** How many dice rolled 1. */
+	public get minCount(): number {
+		return this.core.rolls.filter(roll => roll === 1).length;
+	}
+	/** How many dice rolled max (value equal to .dice.sides). */
+	public get maxCount(): number {
+		return this.core.rolls.filter(roll => roll === this.dice.sides).length;
 	}
 	//#endregion
 
@@ -431,7 +449,7 @@ export class DicePartRoll<T extends DicePartRollCore, U extends TDicePart> exten
 		return new DicePartRoll({
 			objectType: "DicePartRoll",
 			gameType: GameType.None,
-			id: utils.UuidUtils.generate(),
+			id: generate(),
 			dice: dicePart.toJSON(),
 			rolls: rollDice(dicePart.count, dicePart.sides)
 		});
@@ -470,6 +488,7 @@ export class Dice<T extends DiceCore, U extends TDicePart, V extends TDiceRoll> 
 
 	//#region flags
 	public get hasTest(): boolean { return  this.test !== undefined; }
+	public get isD20(): boolean { return this.baseDicePart?.sides === 20; }
 	public get isEmpty(): boolean { return this.diceParts.length === 0 || this.diceParts.filter(dicePart => !dicePart.isEmpty).length === 0; }
 	//#endregion
 
@@ -502,7 +521,7 @@ export class Dice<T extends DiceCore, U extends TDicePart, V extends TDiceRoll> 
 	public toString(outputType?: DiceOutputType): string {
 		const _outputType = outputType === DiceOutputType.S ? DiceOutputType.S : DiceOutputType.M;
 		const output = this.diceParts.map((dicePart, index) => dicePart.toString(index, _outputType)).join(" ");
-		return utils.StringUtils.cleanWhitespace(output);
+		return cleanWhitespace(output);
 	}
 	//#endregion
 
@@ -511,8 +530,8 @@ export class Dice<T extends DiceCore, U extends TDicePart, V extends TDiceRoll> 
 		return new Dice({
 			objectType: "Dice",
 			gameType: GameType.None,
-			id: utils.UuidUtils.generate(),
-			diceParts: diceParts.map<DicePartCore>(utils.ClassUtils.toJSON)
+			id: generate(),
+			diceParts: diceParts.map<DicePartCore>(toJSON)
 		});
 	}
 	public static fromCore(core: DiceCore): TDice {
@@ -574,14 +593,22 @@ export class DiceRoll<T extends DiceRollCore, U extends TDice, V extends TDicePa
 		return this._rolls;
 	}
 	//#region toString
-	protected _toString(renderer: TDicePartRollToString, hideRolls: boolean): string {
+	protected _toString(renderer: TDicePartRollToString, hideRolls: boolean, rollem = false): string {
 		const xxs = this.toStringXXS(hideRolls);
 		const desc = this.dice.diceParts.find(dp => dp.hasDescription)?.description;
-		const description = this.rolls.map((roll, index) => renderer(roll, index, hideRolls)).join(" ");
-		const output = desc
-			? `${xxs} \`${desc}\` ${UNICODE_LEFT_ARROW} ${description.replace(desc, "")}`
-			: `${xxs} ${UNICODE_LEFT_ARROW} ${description}`;
-		return utils.StringUtils.cleanWhitespace(output);
+		const description = this.rolls.map((roll, index) => renderer(roll, index, hideRolls, rollem)).join(" ");
+		if (rollem) {
+			const stripped = xxs.replace(/<\/?(b|em|i|strong)>/ig, "");
+			const output = desc
+				? `'${dequote(desc)}', \` ${stripped} \` ${UNICODE_LEFT_ARROW} ${description.replace(desc, "")}`
+				: `\` ${stripped} \` ${UNICODE_LEFT_ARROW} ${description}`;
+			return cleanWhitespace(output);
+		}else {
+			const output = desc
+				? `${xxs} \`${dequote(desc)}\` ${UNICODE_LEFT_ARROW} ${description.replace(desc, "")}`
+				: `${xxs} ${UNICODE_LEFT_ARROW} ${description}`;
+			return cleanWhitespace(output);
+		}
 	}
 	protected toStringXS(hideRolls: boolean): string {
 		const xxs = this.toStringXXS(hideRolls);
@@ -589,13 +616,13 @@ export class DiceRoll<T extends DiceRollCore, U extends TDice, V extends TDicePa
 		const output = desc
 			? `${xxs} \`${desc ?? ""}\``
 			: xxs;
-		return utils.StringUtils.cleanWhitespace(output);
+		return cleanWhitespace(output);
 	}
 	protected toStringXXS(hideRolls: boolean): string {
 		const gradeEmoji = gradeToEmoji(this.grade),
 			total = hideRolls ? `||${diceTotalToString(this.total)}||` : diceTotalToString(this.total),
 			output = `${hideRolls ? ":question:" : gradeEmoji ?? ""} ${total}`;
-		return utils.StringUtils.cleanWhitespace(output);
+		return cleanWhitespace(output);
 	}
 	public toString(): string;
 	public toString(hideRolls: boolean): string;
@@ -606,6 +633,7 @@ export class DiceRoll<T extends DiceRollCore, U extends TDice, V extends TDicePa
 		const hideRolls = <boolean>args.find(arg => arg === true || arg === false) ?? false;
 		const outputType = <DiceOutputType>args.find(arg => !!(DiceOutputType[<DiceOutputType>arg] ?? false)) ?? DiceOutputType.M;
 		switch (outputType) {
+			case DiceOutputType.ROLLEM: return this._toString(mapDicePartRollToStringWithDice, hideRolls, true);
 			case DiceOutputType.XXL: return this._toString(mapDicePartRollToStringWithDice, hideRolls);
 			case DiceOutputType.XL: return this._toString(mapDicePartRollToStringWithDice, hideRolls);
 			case DiceOutputType.L: return this._toString(mapDicePartRollToStringWithoutDice, hideRolls);
@@ -628,7 +656,7 @@ export class DiceRoll<T extends DiceRollCore, U extends TDice, V extends TDicePa
 			objectType: "DiceRoll",
 			gameType: GameType.None,
 			//Quick rolls can never be reloaded, so we don't need a UUID
-			id: uuid ? utils.UuidUtils.generate() : null!,
+			id: uuid ? generate() : null!,
 			dice: _dice.toJSON(),
 			rolls: _dice.diceParts.map<DicePartRollCore>(mapRollToJson)
 		};
@@ -698,9 +726,9 @@ export class DiceGroup<T extends DiceGroupCore, U extends TDice, V extends TDice
 		return new DiceGroup({
 			objectType: "DiceGroup",
 			gameType: GameType.None,
-			id: utils.UuidUtils.generate(),
+			id: generate(),
 			critMethodType: critMethodType,
-			dice: _dice.map<DiceCore>(utils.ClassUtils.toJSON),
+			dice: _dice.map<DiceCore>(toJSON),
 			diceOutputType: diceOutputType,
 			diceSecretMethodType: diceSecretMethodType
 		});
@@ -741,7 +769,7 @@ export class DiceGroup<T extends DiceGroupCore, U extends TDice, V extends TDice
 		return DiceGroup.create(_dice, diceOutputType, diceSecretMethodType, critMethodType);
 	}
 	public static parse(diceString: string, diceOutputType?: DiceOutputType, diceSecretMethodType?: DiceSecretMethodType): TDiceGroup {
-		const tokens = utils.StringUtils.Tokenizer.tokenize(diceString, getParsers(), "desc");
+		const tokens = Tokenizer.tokenize(diceString, getParsers(), "desc");
 		return DiceGroup.fromTokens(tokens, diceOutputType, diceSecretMethodType);
 	}
 	public static Part = Dice;
@@ -803,7 +831,7 @@ export class DiceGroupRoll<T extends DiceGroupRollCore, U extends TDiceGroup, V 
 			objectType: "DiceGroupRoll",
 			gameType: GameType.None,
 			//Quick rolls can never be reloaded, so we don't need a UUID
-			id: uuid ? utils.UuidUtils.generate() : null!,
+			id: uuid ? generate() : null!,
 			diceGroup: diceGroup.toJSON(),
 			rolls: diceGroup.dice.map<DiceRollCore>(mapRollToJson)
 		});

--- a/src/sage-dice/dice/cnc/index.ts
+++ b/src/sage-dice/dice/cnc/index.ts
@@ -1,7 +1,6 @@
 //#region imports
 
 import type { OrNull, TParsers, TToken } from "../../../sage-utils";
-import utils from "../../../sage-utils";
 import type {
 	TDiceLiteral,
 	TTestData
@@ -24,6 +23,9 @@ import {
 	DiceGroupRoll as baseDiceGroupRoll, DicePart as baseDicePart,
 	DicePartRoll as baseDicePartRoll, DiceRoll as baseDiceRoll
 } from "../base";
+import { generate } from "../../../sage-utils/utils/UuidUtils";
+import { toJSON } from "../../../sage-utils/utils/ClassUtils";
+import { Tokenizer } from "../../../sage-utils/utils/StringUtils";
 
 //#endregion
 
@@ -130,7 +132,7 @@ export class DicePart extends baseDicePart<DicePartCore, DicePartRoll> {
 		return new DicePart({
 			objectType: "DicePart",
 			gameType: GameType.CnC,
-			id: utils.UuidUtils.generate(),
+			id: generate(),
 
 			count: 1,
 			description: cleanDescription(description),
@@ -166,7 +168,7 @@ export class DicePartRoll extends baseDicePartRoll<DicePartRollCore, DicePart> {
 		return new DicePartRoll({
 			objectType: "DicePartRoll",
 			gameType: GameType.CnC,
-			id: utils.UuidUtils.generate(),
+			id: generate(),
 			dice: dicePart.toJSON(),
 			rolls: rollDice(dicePart.count, dicePart.sides)
 		});
@@ -192,8 +194,8 @@ export class Dice extends baseDice<DiceCore, DicePart, DiceRoll> {
 		return new Dice({
 			objectType: "Dice",
 			gameType: GameType.CnC,
-			id: utils.UuidUtils.generate(),
-			diceParts: diceParts.map<DicePartCore>(utils.ClassUtils.toJSON)
+			id: generate(),
+			diceParts: diceParts.map<DicePartCore>(toJSON)
 		});
 	}
 	public static fromCore(core: DiceCore): Dice {
@@ -230,7 +232,7 @@ export class DiceRoll extends baseDiceRoll<DiceRollCore, Dice, DicePartRoll> {
 		return new DiceRoll({
 			objectType: "DiceRoll",
 			gameType: GameType.CnC,
-			id: utils.UuidUtils.generate(),
+			id: generate(),
 			dice: _dice.toJSON(),
 			rolls: _dice.diceParts.map(dicePart => dicePart.roll().toJSON())
 		});
@@ -256,9 +258,9 @@ export class DiceGroup extends baseDiceGroup<DiceGroupCore, Dice, DiceGroupRoll>
 		return new DiceGroup({
 			objectType: "DiceGroup",
 			gameType: GameType.CnC,
-			id: utils.UuidUtils.generate(),
+			id: generate(),
 			critMethodType: undefined,
-			dice: _dice.map<DiceCore>(utils.ClassUtils.toJSON),
+			dice: _dice.map<DiceCore>(toJSON),
 			diceOutputType: diceOutputType,
 			diceSecretMethodType: DiceSecretMethodType.Ignore
 		});
@@ -270,7 +272,7 @@ export class DiceGroup extends baseDiceGroup<DiceGroupCore, Dice, DiceGroupRoll>
 		return DiceGroup.create([Dice.create([DicePart.fromTokens(tokens)])], diceOutputType);
 	}
 	public static parse(diceString: string, diceOutputType?: DiceOutputType): DiceGroup {
-		const tokens = utils.StringUtils.Tokenizer.tokenize(diceString, getParsers(), "desc");
+		const tokens = Tokenizer.tokenize(diceString, getParsers(), "desc");
 		return DiceGroup.fromTokens(tokens, diceOutputType);
 	}
 	public static Part = <typeof baseDice>Dice;
@@ -293,7 +295,7 @@ export class DiceGroupRoll extends baseDiceGroupRoll<DiceGroupRollCore, DiceGrou
 		return new DiceGroupRoll({
 			objectType: "DiceGroupRoll",
 			gameType: GameType.CnC,
-			id: utils.UuidUtils.generate(),
+			id: generate(),
 			diceGroup: diceGroup.toJSON(),
 			rolls: diceGroup.dice.map(_dice => _dice.roll().toJSON())
 		});

--- a/src/sage-dice/dice/discord/index.ts
+++ b/src/sage-dice/dice/discord/index.ts
@@ -1,7 +1,6 @@
 //#region imports
 
 import type { IdCore, OrNull, OrUndefined } from "../../../sage-utils";
-import utils from "../../../sage-utils";
 import {
 	CritMethodType,
 	DiceOutputType,
@@ -24,6 +23,14 @@ import {
 	DiceGroupRoll as baseDiceGroupRoll, DicePart as baseDicePart
 } from "../base";
 import {
+	DiceGroup as dnd5eDiceGroup,
+	DiceGroupRoll as dnd5eDiceGroupRoll
+} from "../dnd5e";
+import {
+	DiceGroup as e20DiceGroup,
+	DiceGroupRoll as e20DiceGroupRoll
+} from "../essence20";
+import {
 	DiceGroup as pf2eDiceGroup,
 	DiceGroupRoll as pf2eDiceGroupRoll
 } from "../pf2e";
@@ -31,29 +38,37 @@ import {
 	DiceGroup as questDiceGroup,
 	DiceGroupRoll as questDiceGroupRoll
 } from "../quest";
+import { generate } from "../../../sage-utils/utils/UuidUtils";
+import { HasCore, toJSON } from "../../../sage-utils/utils/ClassUtils";
 
 //#endregion
 
 const DICE_REGEX = /\[[^\]]*d\d+[^\]]*\]/ig;
-const GAME_CHECK = /^(dnd5e|pf1e|pf2e|pf1|pf2|pf|sf1e|sf1|sf|5e|quest)?/i;
+const GAME_CHECK = /^(dnd5e|e20|pf1e|pf2e|pf1|pf2|pf|sf1e|sf1|sf|5e|quest)?/i;
 const DICE_OUTPUT_CHECK = /^(xxs|xs|s|m|xxl|xl|l)?/i;
 const COUNT_CHECK = /^(\d+)(map\-\d+)?\#/i;
 
 function getDiceGroupForGame(gameType: GameType): typeof baseDiceGroup {
 	switch (gameType) {
-		case GameType.Quest: return <typeof baseDiceGroup>questDiceGroup;
+		case GameType.DnD5e: return <typeof baseDiceGroup>dnd5eDiceGroup;
+		case GameType.E20: return <typeof baseDiceGroup>e20DiceGroup;
 		case GameType.PF2e: return <typeof baseDiceGroup>pf2eDiceGroup;
+		case GameType.Quest: return <typeof baseDiceGroup>questDiceGroup;
 		default: return baseDiceGroup;
 	}
 }
 
 function parseDice(diceString: string, gameType?: GameType, diceOutputType?: DiceOutputType, diceSecretMethodType?: DiceSecretMethodType, critMethodType?: CritMethodType): baseTDiceGroup {
 	switch (gameType) {
-		case GameType.Quest:
-			return questDiceGroup.parse(diceString, diceOutputType);
+		case GameType.DnD5e:
+			return dnd5eDiceGroup.parse(diceString, diceOutputType, diceSecretMethodType, critMethodType);
+		case GameType.E20:
+			return e20DiceGroup.parse(diceString, diceOutputType);
 		case GameType.PF2e:
 			return pf2eDiceGroup.parse(diceString, diceOutputType, diceSecretMethodType, critMethodType);
-		default:
+		case GameType.Quest:
+			return questDiceGroup.parse(diceString, diceOutputType);
+			default:
 			return baseDiceGroup.parse(diceString, diceOutputType, diceSecretMethodType);
 	}
 }
@@ -64,7 +79,7 @@ function cloneDicePart<T extends baseDicePartCore, U extends baseTDicePart>(clss
 		description: core.description,
 		dropKeep: core.dropKeep ? { ...core.dropKeep } : undefined,
 		gameType: core.gameType,
-		id: utils.UuidUtils.generate(),
+		id: generate(),
 		modifier: core.modifier,
 		noSort: core.noSort,
 		objectType: core.objectType,
@@ -84,7 +99,7 @@ function cloneDice<T extends baseDiceCore, U extends baseTDice>(clss: typeof bas
 			description: "<i>(MAP)</i>",
 			dropKeep: undefined,
 			gameType: gameType,
-			id: utils.UuidUtils.generate(),
+			id: generate(),
 			modifier: Math.abs(map),
 			noSort: false,
 			objectType: "DicePart",
@@ -106,7 +121,7 @@ function cloneDice<T extends baseDiceCore, U extends baseTDice>(clss: typeof bas
 				diceParts.splice(diceParts.indexOf(testCore), 0, mapCore);
 			}else {
 				// split dice/mod from test
-				// const newTestCore = <baseDicePartCore>{ count:0, description:"", dropKeep:null, gameType:gameType, id:utils.UuidUtils.generate(), modifier:0, noSort:false, objectType:"DicePart", sides:0, sign:"+", test:testCore.test };
+				// const newTestCore = <baseDicePartCore>{ count:0, description:"", dropKeep:null, gameType:gameType, id:generate(), modifier:0, noSort:false, objectType:"DicePart", sides:0, sign:"+", test:testCore.test };
 				mapCore.test = testCore.test;
 				delete testCore.test;
 				//put mapCore and newTestCore after testCore //, newTestCore); <-- after splice
@@ -117,7 +132,7 @@ function cloneDice<T extends baseDiceCore, U extends baseTDice>(clss: typeof bas
 	return <U>clss.fromCore({
 		diceParts: diceParts,
 		gameType: core.gameType,
-		id: utils.UuidUtils.generate(),
+		id: generate(),
 		objectType: <"Dice">core.objectType
 	});
 }
@@ -129,7 +144,7 @@ function cloneDiceGroup<T extends baseDiceGroupCore, U extends baseTDiceGroup>(c
 		diceOutputType: core.diceOutputType,
 		diceSecretMethodType: core.diceSecretMethodType,
 		gameType: core.gameType,
-		id: utils.UuidUtils.generate(),
+		id: generate(),
 		objectType: <"DiceGroup">core.objectType
 	});
 }
@@ -138,16 +153,20 @@ interface DiscordDiceCore extends IdCore<"DiscordDice"> {
 	diceGroups: baseDiceGroupCore[];
 }
 
-export class DiscordDice extends utils.ClassUtils.HasCore<DiscordDiceCore, "DiscordDice"> {
+export class DiscordDice extends HasCore<DiscordDiceCore, "DiscordDice"> {
 	private _diceGroups?: baseTDiceGroup[];
 	public get diceGroups(): baseTDiceGroup[] {
 		if (!this._diceGroups) {
 			this._diceGroups = this.core.diceGroups.map(core => {
 				switch (core.gameType) {
-					case GameType.Quest:
-						return questDiceGroup.fromCore(core);
+					case GameType.DnD5e:
+						return dnd5eDiceGroup.fromCore(core);
+					case GameType.E20:
+						return e20DiceGroup.fromCore(core);
 					case GameType.PF2e:
 						return pf2eDiceGroup.fromCore(core);
+					case GameType.Quest:
+						return questDiceGroup.fromCore(core);
 					default:
 						return baseDiceGroup.fromCore(core);
 				}
@@ -169,8 +188,8 @@ export class DiscordDice extends utils.ClassUtils.HasCore<DiscordDiceCore, "Disc
 	public static create(diceGroups: baseTDiceGroup[]): DiscordDice {
 		const core: DiscordDiceCore = {
 			objectType: "DiscordDice",
-			id: utils.UuidUtils.generate(),
-			diceGroups: diceGroups.map<baseDiceGroupCore>(utils.ClassUtils.toJSON)
+			id: generate(),
+			diceGroups: diceGroups.map<baseDiceGroupCore>(toJSON)
 		};
 		return new DiscordDice(core);
 	}
@@ -286,7 +305,7 @@ interface DiscordDiceRollCore extends IdCore<"DiscordDiceRoll"> {
 	rolls: baseDiceGroupRollCore[];
 }
 
-export class DiscordDiceRoll extends utils.ClassUtils.HasCore<DiscordDiceRollCore> {
+export class DiscordDiceRoll extends HasCore<DiscordDiceRollCore> {
 	private _discordDice?: DiscordDice;
 	public get discordDice(): DiscordDice {
 		if (!this._discordDice) {
@@ -300,10 +319,14 @@ export class DiscordDiceRoll extends utils.ClassUtils.HasCore<DiscordDiceRollCor
 		if (!this._rolls) {
 			this._rolls = this.core.rolls.map(core => {
 				switch (core.gameType) {
-					case GameType.Quest:
-						return questDiceGroupRoll.fromCore(core);
+					case GameType.DnD5e:
+						return dnd5eDiceGroupRoll.fromCore(core);
+					case GameType.E20:
+						return e20DiceGroupRoll.fromCore(core);
 					case GameType.PF2e:
 						return pf2eDiceGroupRoll.fromCore(core);
+					case GameType.Quest:
+						return questDiceGroupRoll.fromCore(core);
 					default:
 						return baseDiceGroupRoll.fromCore(core);
 				}
@@ -342,7 +365,7 @@ export class DiscordDiceRoll extends utils.ClassUtils.HasCore<DiscordDiceRollCor
 	public static create(discordDice: DiscordDice): DiscordDiceRoll {
 		const core: DiscordDiceRollCore = {
 			objectType: "DiscordDiceRoll",
-			id: utils.UuidUtils.generate(),
+			id: generate(),
 			discordDice: discordDice.toJSON(),
 			rolls: discordDice.diceGroups.map(diceGroup => diceGroup.roll().toJSON())
 		};

--- a/src/sage-dice/dice/dnd5e/index.ts
+++ b/src/sage-dice/dice/dnd5e/index.ts
@@ -1,0 +1,506 @@
+//#region imports
+
+import type { OrNull, OrUndefined, TParsers, TToken } from "../../../sage-utils";
+import { exists } from "../../../sage-utils/utils/ArrayUtils/Filters";
+import { toJSON } from "../../../sage-utils/utils/ClassUtils";
+import { Tokenizer } from "../../../sage-utils/utils/StringUtils";
+import { generate } from "../../../sage-utils/utils/UuidUtils";
+import {
+	cleanDescription,
+	createValueTestData, CritMethodType, DiceOutputType,
+	DiceSecretMethodType,
+	DieRollGrade,
+	DropKeepType,
+	GameType, isGradeSuccess,
+	parseTestType,
+	rollDice, TDiceLiteral, TestType, TSign,
+	TTestData
+} from "../../common";
+import {
+	Dice as baseDice, DiceGroup as baseDiceGroup,
+	DiceGroupRoll as baseDiceGroupRoll, DicePart as baseDicePart,
+	DicePartRoll as baseDicePartRoll, DiceRoll as baseDiceRoll, getParsers as baseGetParsers,
+	reduceTokenToDicePartCore as baseReduceTokenToDicePartCore,
+	TReduceSignToDropKeep
+} from "../base";
+import type {
+	DiceCore as baseDiceCore, DiceGroupCore as baseDiceGroupCore,
+	DiceGroupRollCore as baseDiceGroupRollCore, DicePartCore as baseDicePartCore,
+	DicePartRollCore as baseDicePartRollCore, DiceRollCore as baseDiceRollCore, TDicePartCoreArgs as baseTDicePartCoreArgs
+} from "../base/types";
+
+//#endregion
+
+//#region Tokenizer
+function getParsers(): TParsers {
+	const parsers = baseGetParsers();
+	parsers["target"] = /(vs\s*ac|vs\s*dc|ac|dc|vs)\s*(\d+)/i;
+	return parsers;
+}
+const ADVANTAGE = "Advantage";
+const DISADVANTAGE = "Disadvantage";
+function reduceTokenToDicePartCore<T extends DicePartCore>(core: T, token: TToken, index: number, tokens: TToken[]): T {
+	if (token.type === "target") {
+		core.target = parseTargetData(token);
+		return core;
+	}
+	const reduceSignToDropKeepData: TReduceSignToDropKeep[] = [];
+	if (token.type === "dice") {
+		reduceSignToDropKeepData.push(
+			{ sign:"+" as TSign, type:DropKeepType.KeepHighest, value:1, alias:ADVANTAGE, test:_core => _core.count === 2 && _core.sides === 20 && _core.sign === "+" },
+			{ sign:"-" as TSign, type:DropKeepType.KeepLowest, value:1, alias:DISADVANTAGE, test:_core => _core.count === 2 && _core.sides === 20 && _core.sign === "-" }
+		);
+	}
+	return baseReduceTokenToDicePartCore(core, token, index, tokens, reduceSignToDropKeepData);
+}
+//#endregion
+
+//#region Targets/Tests
+export enum TargetType { None = 0, AC = 1, DC = 2, VS = 3 }
+export type TTargetData = { type:TargetType; value:number; raw:string; };
+function parseTargetType(targetType: string): TargetType {
+	const targetTypeLower = targetType.toLowerCase();
+	if (targetTypeLower.endsWith("ac")) {
+		return TargetType.AC;
+	}else if (targetTypeLower.endsWith("dc")) {
+		return TargetType.DC;
+	}else if (targetTypeLower.endsWith("vs")) {
+		return TargetType.VS;
+	}else {
+		return TargetType.None;
+	}
+}
+function parseTargetValue(type: TargetType, value: number): number {
+	return type ? value : 0;
+}
+function parseTargetData(token: TToken): OrUndefined<TTargetData> {
+	if (token.matches) {
+		const type = parseTargetType(token.matches[0]),
+			value = parseTargetValue(type, +token.matches[1] || 0);
+		return { type:type, value:value, raw:token.token };
+	}
+	return undefined;
+}
+function targetDataToTestData(targetData: TTargetData | TTestData): OrUndefined<TTestData> {
+	if (targetData) {
+		const alias = (<TTestData>targetData).alias;
+		if (alias) {
+			const testType = parseTestType(alias);
+			if (testType) {
+				return createValueTestData(testType, targetData.value);
+			}
+		}
+		return createValueTestData(TestType.GreaterThanOrEqual, targetData.value, TargetType[targetData.type].toLowerCase());
+	}
+	return undefined;
+}
+//#endregion
+
+//#region Grades
+
+function gradeResults(roll: DiceRoll): DieRollGrade {
+	const test = roll.dice.test;
+	if (!test) {
+		return DieRollGrade.Unknown;
+	}
+
+	if (roll.isMax) {
+		return DieRollGrade.CriticalSuccess;
+	}else if (roll.isMin) {
+		return DieRollGrade.CriticalFailure;
+	}
+	return roll.total >= test.value ? DieRollGrade.Success : DieRollGrade.Failure;
+}
+
+//#endregion
+
+//#region diceGroupRollToString
+
+function diceGroupRollToString(diceGroupRoll: DiceGroupRoll, outputType: DiceOutputType, joiner = "\n"): string {
+	const rollOutputs: string[] = [],
+		attackRoll = diceGroupRoll.attackRoll;
+	if (attackRoll) {
+		rollOutputs.push(attackRoll.toString(outputType));
+
+		const attackGrade = attackRoll?.grade ?? DieRollGrade.Unknown;
+		const showRolls = !attackGrade || isGradeSuccess(attackGrade);
+		if (showRolls) {
+			const damageRoll = diceGroupRoll.damageRoll;
+			if (damageRoll) {
+				const dmgEmoji = attackGrade ? `[damage] ` : ``;
+				rollOutputs.push(`${dmgEmoji}${damageRoll.toString(outputType)}`);
+			}
+
+			diceGroupRoll.otherRolls.forEach(diceRoll => rollOutputs.push(diceRoll.toString(outputType)));
+		}
+	}else {
+		diceGroupRoll.rolls.forEach(diceRoll => rollOutputs.push(diceRoll.toString(outputType)));
+	}
+	return rollOutputs.join(joiner);
+}
+//#endregion
+
+//#region DicePart
+interface DicePartCore extends baseDicePartCore {
+	target?: TTargetData;
+}
+type TDicePartCoreArgs = baseTDicePartCoreArgs & {
+	testOrTarget?: TTestData | TTargetData;
+};
+export class DicePart extends baseDicePart<DicePartCore, DicePartRoll> {
+	//#region flags
+	public get hasAdvantage(): boolean {
+		return this.dropKeep?.alias === ADVANTAGE;
+	}
+	public get hasDisadvantage(): boolean {
+		return this.dropKeep?.alias === DISADVANTAGE;
+	}
+	//#endregion
+
+	//#region static
+	public static create({ count, sides, dropKeep, noSort, modifier, sign, description, testOrTarget }: TDicePartCoreArgs = {}): DicePart {
+		return new DicePart({
+			objectType: "DicePart",
+			gameType: GameType.DnD5e,
+			id: generate(),
+
+			count: count ?? 0,
+			description: cleanDescription(description),
+			dropKeep: dropKeep,
+			modifier: modifier ?? 0,
+			noSort: noSort === true,
+			sides: sides ?? 0,
+			sign: sign,
+			test: targetDataToTestData(<TTargetData>testOrTarget) ?? <TTestData>testOrTarget,
+			target: <TTargetData>testOrTarget
+		});
+	}
+	public static fromCore(core: DicePartCore): DicePart {
+		return new DicePart(core);
+	}
+	public static fromTokens(tokens: TToken[]): DicePart {
+		const core = tokens.reduce(reduceTokenToDicePartCore, <DicePartCore>{ description:"" });
+		const args = <TDicePartCoreArgs>{ testOrTarget:core.target ?? core.test, ...core };
+		return DicePart.create(args);
+	}
+	//#endregion
+}
+//#endregion
+
+//#region DicePartRoll
+type DicePartRollCore = baseDicePartRollCore;
+export class DicePartRoll extends baseDicePartRoll<DicePartRollCore, DicePart> {
+	//#region static
+	public static create(dicePart: DicePart): DicePartRoll {
+		return new DicePartRoll({
+			objectType: "DicePartRoll",
+			gameType: GameType.DnD5e,
+			id: generate(),
+			dice: dicePart.toJSON(),
+			rolls: rollDice(dicePart.count, dicePart.sides)
+		});
+	}
+	public static fromCore(core: DicePartRollCore): DicePartRoll {
+		return new DicePartRoll(core);
+	}
+	public static Dice = <typeof baseDicePart>DicePart;
+	//#endregion
+}
+DicePart.Roll = <typeof baseDicePartRoll>DicePartRoll;
+//#endregion
+
+//#region Dice
+type DiceCore = baseDiceCore;
+export class Dice extends baseDice<DiceCore, DicePart, DiceRoll> {
+
+	//#region static
+	public static create(diceParts: DicePart[]): Dice {
+		return new Dice({
+			objectType: "Dice",
+			gameType: GameType.DnD5e,
+			id: generate(),
+			diceParts: diceParts.map<DicePartCore>(toJSON)
+		});
+	}
+	public static fromCore(core: DiceCore): Dice {
+		return new Dice(core);
+	}
+	public static fromDicePartCores(dicePartCores: DicePartCore[]): Dice {
+		return Dice.create(dicePartCores.map(DicePart.fromCore));
+	}
+	public static parse(diceString: string): Dice {
+		const diceGroup = DiceGroup.parse(diceString);
+		return diceGroup && diceGroup.dice[0] || null;
+	}
+	public static roll(diceString: TDiceLiteral): number;
+	public static roll(diceString: string): OrNull<number>;
+	public static roll(diceString: string): OrNull<number> {
+		const _dice = Dice.parse(diceString);
+		return _dice?.quickRoll() ?? null;
+	}
+
+	public static Part = <typeof baseDicePart>DicePart;
+	//#endregion
+}
+//#endregion
+
+//#region DiceRoll
+type DiceRollCore = baseDiceRollCore;
+export class DiceRoll extends baseDiceRoll<DiceRollCore, Dice, DicePartRoll> {
+	//#region calculated
+	public get grade(): DieRollGrade { return gradeResults(this); }
+	//#endregion
+
+	//#region static
+	public static create(_dice: Dice): DiceRoll {
+		return new DiceRoll({
+			objectType: "DiceRoll",
+			gameType: GameType.DnD5e,
+			id: generate(),
+			dice: _dice.toJSON(),
+			rolls: _dice.diceParts.map(dicePart => dicePart.roll().toJSON())
+		});
+	}
+	public static fromCore(core: DiceRollCore): DiceRoll {
+		return new DiceRoll(core);
+	}
+	public static Dice = <typeof baseDice>Dice;
+	//#endregion
+}
+Dice.Roll = <typeof baseDiceRoll>DiceRoll;
+//#endregion
+
+//#region DiceGroup
+function isTestOrTarget(currentToken: TToken): boolean {
+	return ["test","target"].includes(currentToken.type);
+}
+function shouldStartNewPart(currentPart: TToken[], currentToken: TToken): boolean {
+	return !currentPart || ["dice","mod","test","target"].includes(currentToken.type);
+}
+
+interface DiceGroupCore extends baseDiceGroupCore {
+	critMethodType?: CritMethodType;
+}
+export class DiceGroup extends baseDiceGroup<DiceGroupCore, Dice, DiceGroupRoll> {
+	public get critMethodType(): CritMethodType { return this.core.critMethodType ?? CritMethodType.Unknown; }
+
+	//#region Attack
+	public get hasAttackDice(): boolean {
+		return this.attackDice !== null;
+	}
+	public get attackDice(): OrNull<Dice> {
+		const testDice: Dice[] = [];
+		const attackDice = this.dice.find(_dice => _dice.isD20 && (!_dice.test || !testDice.includes(_dice)));
+		if (attackDice) {
+			testDice.push(attackDice);
+			const damageDice = this.dice.find(_dice => !_dice.isD20 && !_dice.test && !testDice.includes(_dice));
+			if (damageDice) {
+				return attackDice;
+			}
+		}
+		return null;
+	}
+	//#endregion
+
+	//#region Damage
+	public get hasDamageDice(): boolean {
+		return this.damageDice !== null;
+	}
+	public get damageDice(): OrNull<Dice> {
+		const attackDice = this.attackDice;
+		if (attackDice) {
+			const testDice: Dice[] = [attackDice];
+			return this.dice.find(_dice => !_dice.isD20 && !_dice.test && !testDice.includes(_dice)) ?? null;
+		}
+		return null;
+	}
+	//#endregion
+
+	//#region Others
+	public get hasOtherDice(): boolean {
+		return this.otherDice.length > 0;
+	}
+	public get otherDice(): Dice[] {
+		const nonOtherDice = [this.attackDice, this.damageDice]
+			.filter(exists);
+		return this.dice.filter(_dice => !nonOtherDice.includes(_dice));
+	}
+	//#endregion
+
+	public toString(outputType?: DiceOutputType): string {
+		const sortedDice = [this.attackDice, this.damageDice]
+			.concat(this.otherDice)
+			.filter(exists);
+		return `[${sortedDice.map(_dice => _dice.toString(outputType)).join("; ")}]`;
+	}
+
+	//#region static
+	public static create(_dice: Dice[], diceOutputType?: DiceOutputType, diceSecretMethodType?: DiceSecretMethodType, critMethodType = CritMethodType.Unknown): DiceGroup {
+		return new DiceGroup({
+			objectType: "DiceGroup",
+			gameType: GameType.DnD5e,
+			id: generate(),
+			critMethodType: critMethodType,
+			dice: _dice.map<DiceCore>(toJSON),
+			diceOutputType: diceOutputType,
+			diceSecretMethodType: diceSecretMethodType
+		});
+	}
+	public static fromCore(core: DiceGroupCore): DiceGroup {
+		return new DiceGroup(core);
+	}
+	public static fromTokens(tokens: TToken[], diceOutputType?: DiceOutputType, diceSecretMethodType?: DiceSecretMethodType, critMethodType?: CritMethodType): DiceGroup {
+		let currentPart: TToken[];
+		const partedTokens: TToken[][] = [];
+		tokens.forEach(token => {
+			if (shouldStartNewPart(currentPart, token)) {
+				currentPart = [];
+				partedTokens.push(currentPart);
+			}
+			currentPart.push(token);
+			if (isTestOrTarget(token)) {
+				currentPart = [];
+				partedTokens.push(currentPart);
+			}
+		});
+		const diceParts = partedTokens.filter(array => array.length).map(DicePart.fromTokens);
+
+		let currentDice: DicePart[];
+		const partedDice: DicePart[][] = [];
+		diceParts.forEach(dicePart => {
+			if (!currentDice
+				|| dicePart.hasDie && !dicePart.sign
+				|| dicePart.hasTest && currentDice.find(_dicePart => _dicePart.hasTest)) {
+				currentDice = [];
+				partedDice.push(currentDice);
+			}
+			currentDice.push(dicePart);
+		});
+
+		partedDice.forEach(_diceParts => {
+			if (_diceParts.length === 1) {
+				const _dicePart = _diceParts[0];
+				if (_dicePart.hasTest && _dicePart.isEmpty) {
+					const _core = _dicePart.toJSON();
+					_core.count = 1;
+					_core.sides = 20;
+				}
+			}
+		});
+
+		const _dice = partedDice.map(Dice.create);
+		return DiceGroup.create(_dice, diceOutputType, diceSecretMethodType, critMethodType);
+	}
+	public static parse(diceString: string, diceOutputType?: DiceOutputType, diceSecretMethodType?: DiceSecretMethodType, critMethodType?: CritMethodType): DiceGroup {
+		const tokens = Tokenizer.tokenize(diceString, getParsers(), "desc");
+		return DiceGroup.fromTokens(tokens, diceOutputType, diceSecretMethodType, critMethodType);
+	}
+	public static Part = <typeof baseDice>Dice;
+	public static Roll: typeof baseDiceGroupRoll;
+	//#endregion
+}
+//#endregion
+
+//#region DiceGroupRoll
+function createDiceGroupRoll(diceGroup: DiceGroup): DiceGroupRoll {
+	const core: DiceGroupRollCore = {
+		objectType: "DiceGroupRoll",
+		gameType: GameType.DnD5e,
+		id: generate(),
+		diceGroup: diceGroup.toJSON(),
+		rolls: diceGroup.dice.map(_dice => _dice.roll().toJSON())
+	};
+	const diceGroupRoll = new DiceGroupRoll(core);
+	manipulateDamage(diceGroupRoll);
+	return diceGroupRoll;
+}
+function manipulateDamage(diceGroupRoll: DiceGroupRoll): void {
+	if (diceGroupRoll.hasAttackAndDamage) {
+		manipulateCriticalDamage(diceGroupRoll);
+	}
+}
+
+function critByTimesTwo(diceGroupRoll: DiceGroupRoll): void {
+	const critDicePart = DicePart.create({ modifier: 2, sign: "*", description: "<i>(crit)</i>" });
+	diceGroupRoll.dice.damageDice!.diceParts.push(critDicePart);
+	diceGroupRoll.damageRoll!.toJSON().rolls.push(critDicePart.roll().toJSON());
+}
+function critByRollingTwice(diceGroupRoll: DiceGroupRoll): void {
+	const damageDice = diceGroupRoll.dice.damageDice!;
+	const damageRoll = diceGroupRoll.damageRoll!;
+	damageDice.diceParts.forEach((dicePart, index) => {
+		if (dicePart.hasDie) {
+			damageRoll.toJSON().rolls[index].rolls.push(...dicePart.roll().rolls);
+			dicePart.toJSON().count *= 2;
+		}else if (dicePart.modifier) {
+			dicePart.toJSON().modifier *= 2;
+		}
+	});
+
+	const critDicePart = DicePart.create({ description: "<i>(crit; roll 2x)</i>" });
+	damageDice.diceParts.push(critDicePart);
+	damageRoll.toJSON().rolls.push(critDicePart.roll().toJSON());
+}
+function critByAddingMax(diceGroupRoll: DiceGroupRoll): void {
+	const critDicePart = DicePart.create({ modifier: diceGroupRoll.damageRoll!.dice.max, sign: "+", description: "<i>(crit; add max)</i>" });
+	diceGroupRoll.dice.damageDice!.diceParts.push(critDicePart);
+	diceGroupRoll.damageRoll!.toJSON().rolls.push(critDicePart.roll().toJSON());
+}
+
+function manipulateCriticalDamage(diceGroupRoll: DiceGroupRoll): void {
+	if (diceGroupRoll.hasAttackCriticalSuccess) {
+		const critMethodType = diceGroupRoll.dice.critMethodType;
+		if (critMethodType === CritMethodType.AddMax) {
+			critByAddingMax(diceGroupRoll);
+		} else if (critMethodType === CritMethodType.RollTwice) {
+			critByRollingTwice(diceGroupRoll);
+		}else {
+			critByTimesTwo(diceGroupRoll);
+		}
+	}
+}
+
+type DiceGroupRollCore = baseDiceGroupRollCore;
+export class DiceGroupRoll extends baseDiceGroupRoll<DiceGroupRollCore, DiceGroup, DiceRoll> {
+	public get attackRoll(): OrNull<DiceRoll> {
+		const attackDice = this.dice.attackDice;
+		return attackDice ? DiceRoll.fromCore(this.core.rolls.find(rollCore => attackDice.is(rollCore.dice))!) : null;
+	}
+	public get damageRoll(): OrNull<DiceRoll> {
+		const damageDice = this.dice.damageDice;
+		return damageDice ? DiceRoll.fromCore(this.core.rolls.find(rollCore => damageDice.is(rollCore.dice))!) : null;
+	}
+	public get otherRolls(): DiceRoll[] {
+		const nonOtherRolls = [this.attackRoll, this.damageRoll]
+			.filter(exists);
+		return this.core.rolls.filter(rollCore => !nonOtherRolls.find(roll => roll.is(rollCore))).map(DiceRoll.fromCore);
+	}
+
+	//#region convenience / flags
+	public get hasAttackAndDamage(): boolean {
+		return this.dice.hasAttackDice && this.dice.hasDamageDice;
+	}
+	public get hasAttackCriticalSuccess(): boolean {
+		return this.attackRoll?.grade === DieRollGrade.CriticalSuccess;
+	}
+	//#endregion
+
+	public toString(outputType?: DiceOutputType, inline = false): string {
+		let _outputType = this.dice.diceOutputType ?? outputType ?? DiceOutputType.M;
+		if (inline) {
+			_outputType = <DiceOutputType>Math.min(_outputType, DiceOutputType.M);
+		}
+		const joiner = _outputType < DiceOutputType.L ? "; " : "\n";
+		return diceGroupRollToString(this, _outputType, joiner);
+	}
+
+	public static create(diceGroup: DiceGroup): DiceGroupRoll {
+		return createDiceGroupRoll(diceGroup);
+	}
+	public static fromCore(core: DiceGroupRollCore): DiceGroupRoll {
+		return new DiceGroupRoll(core);
+	}
+	public static Dice = <typeof baseDiceGroup>DiceGroup;
+}
+DiceGroup.Roll = <typeof baseDiceGroupRoll>DiceGroupRoll;
+//#endregion

--- a/src/sage-dice/dice/essence20/index.ts
+++ b/src/sage-dice/dice/essence20/index.ts
@@ -1,0 +1,332 @@
+//#region imports
+
+import type { OrNull, OrUndefined, TParsers, TToken } from "../../../sage-utils";
+import { toJSON } from "../../../sage-utils/utils/ClassUtils";
+import { Tokenizer } from "../../../sage-utils/utils/StringUtils";
+import { generate } from "../../../sage-utils/utils/UuidUtils";
+import {
+	cleanDescription,
+	createValueTestData, DiceOutputType,
+	DiceSecretMethodType, DropKeepType, GameType, rollDice, TDiceLiteral, TestType, TSign,
+	TTestData
+} from "../../common";
+import {
+	Dice as baseDice, DiceGroup as baseDiceGroup,
+	DiceGroupRoll as baseDiceGroupRoll, DicePart as baseDicePart,
+	DicePartRoll as baseDicePartRoll, DiceRoll as baseDiceRoll, getParsers as baseGetParsers,
+	reduceTokenToDicePartCore as baseReduceTokenToDicePartCore,
+	TReduceSignToDropKeep
+} from "../base";
+import type {
+	DiceCore as baseDiceCore, DiceGroupCore as baseDiceGroupCore,
+	DiceGroupRollCore as baseDiceGroupRollCore, DicePartCore as baseDicePartCore,
+	DicePartRollCore as baseDicePartRollCore, DiceRollCore as baseDiceRollCore, TDicePartCoreArgs as baseTDicePartCoreArgs
+} from "../base/types";
+
+//#endregion
+
+//#region Tokenizer
+function getParsers(): TParsers {
+	const parsers = baseGetParsers();
+	parsers["bang"] = /\!/;
+	parsers["target"] = /\b(vs\s*dif|dif|vs)\s*(\d+)/i;
+	return parsers;
+}
+const EDGE = "Edge";
+const SNAG = "Snag";
+function reduceTokenToDicePartCore<T extends DicePartCore>(core: T, token: TToken, index: number, tokens: TToken[]): T {
+	if (token.type === "bang") {
+		const prevToken = tokens[index - 1];
+		if (prevToken?.type === "dice") {
+			core.specialization = true;
+			return core;
+		}
+	}
+	if (token.type === "target") {
+		core.target = parseTargetData(token);
+		return core;
+	}
+	const reduceSignToDropKeepData: TReduceSignToDropKeep[] = [];
+	if (token.type === "dice") {
+		reduceSignToDropKeepData.push(
+			{ sign:"+" as TSign, type:DropKeepType.KeepHighest, value:1, alias:EDGE, test:_core => _core.sign === "+" },
+			{ sign:"-" as TSign, type:DropKeepType.KeepLowest, value:1, alias:SNAG, test:_core => _core.sign === "-" }
+		);
+	}
+	return baseReduceTokenToDicePartCore(core, token, index, tokens, reduceSignToDropKeepData);
+}
+//#endregion
+
+//#region Targets/Tests
+enum TargetType { None = 0, DIF = 1 }
+type TTargetData = { type:TargetType; value:number; raw:string; };
+function parseTargetData(token: TToken): OrUndefined<TTargetData> {
+	if (token.matches) {
+		const type = TargetType.DIF,
+			value = +token.matches[1] || 0;
+		return { type:type, value:value, raw:token.token };
+	}
+	return undefined;
+}
+function targetDataToTestData(targetData: TTargetData): OrNull<TTestData> {
+	return !targetData ? null : createValueTestData(TestType.GreaterThanOrEqual, targetData.value, "dif");
+}
+//#endregion
+
+//#region DicePart
+interface DicePartCore extends baseDicePartCore {
+	specialization?: boolean;
+	target?: TTargetData;
+}
+type TDicePartCoreArgs = baseTDicePartCoreArgs & {
+	specialization?: boolean;
+	testOrTarget?: TTestData | TTargetData;
+};
+export class DicePart extends baseDicePart<DicePartCore, DicePartRoll> {
+	public get hasSpecialiation(): boolean { return this.core.specialization === true; }
+	//#region static
+	public static create({ count, description, dropKeep, sides, specialization, testOrTarget }: TDicePartCoreArgs = {}): DicePart {
+		return new DicePart({
+			objectType: "DicePart",
+			gameType: GameType.E20,
+			id: generate(),
+
+			count: count ?? 1,
+			description: cleanDescription(description),
+			dropKeep: dropKeep ?? undefined,
+			modifier: 0,
+			noSort: false,
+			sides: sides ?? 0,
+			sign: undefined,
+			specialization,
+			test: targetDataToTestData(<TTargetData>testOrTarget) ?? <TTestData>testOrTarget ?? null,
+			target: <TTargetData>testOrTarget ?? null
+		});
+	}
+	public static fromCore(core: DicePartCore): DicePart {
+		return new DicePart(core);
+	}
+	public static fromTokens(tokens: TToken[]): DicePart {
+		const core = tokens.reduce(reduceTokenToDicePartCore, <DicePartCore>{ description:"" });
+		if (core.sides !== 20 && core.description.startsWith("!")) {
+			core.specialization = true;
+			core.description = core.description.slice(1);
+		}
+		const args = <TDicePartCoreArgs>{ testOrTarget:core.target ?? core.test, ...core };
+		return DicePart.create(args);
+	}
+	//#endregion
+}
+//#endregion
+
+//#region DicePartRoll
+type DicePartRollCore = baseDicePartRollCore;
+export class DicePartRoll extends baseDicePartRoll<DicePartRollCore, DicePart> {
+	//#region static
+	public static create(dicePart: DicePart): DicePartRoll {
+		return new DicePartRoll({
+			objectType: "DicePartRoll",
+			gameType: GameType.E20,
+			id: generate(),
+			dice: dicePart.toJSON(),
+			rolls: rollDice(dicePart.count, dicePart.sides)
+		});
+	}
+	public static fromCore(core: DicePartRollCore): DicePartRoll {
+		return new DicePartRoll(core);
+	}
+	public static Dice = <typeof baseDicePart>DicePart;
+	//#endregion
+}
+DicePart.Roll = <typeof baseDicePartRoll>DicePartRoll;
+//#endregion
+
+//#region Dice
+type DiceCore = baseDiceCore;
+export class Dice extends baseDice<DiceCore, DicePart, DiceRoll> {
+	//#region static
+	public static create(diceParts: DicePart[]): Dice {
+		return new Dice({
+			objectType: "Dice",
+			gameType: GameType.E20,
+			id: generate(),
+			diceParts: diceParts.map<DicePartCore>(toJSON)
+		});
+	}
+	public static fromCore(core: DiceCore): Dice {
+		return new Dice(core);
+	}
+	public static fromDicePartCores(dicePartCores: DicePartCore[]): Dice {
+		return Dice.create(dicePartCores.map(DicePart.fromCore));
+	}
+	public static parse(diceString: string): Dice {
+		const diceGroup = DiceGroup.parse(diceString);
+		return diceGroup && diceGroup.dice[0] || null;
+	}
+	public static roll(diceString: TDiceLiteral): number;
+	public static roll(diceString: string): OrNull<number>;
+	public static roll(diceString: string): OrNull<number> {
+		const _dice = Dice.parse(diceString);
+		return _dice?.quickRoll() ?? null;
+	}
+
+	public static Part = <typeof baseDicePart>DicePart;
+	//#endregion
+}
+//#endregion
+
+//#region DiceRoll
+type DiceRollCore = baseDiceRollCore;
+export class DiceRoll extends baseDiceRoll<DiceRollCore, Dice, DicePartRoll> {
+	//#region static
+	public static create(_dice: Dice): DiceRoll {
+		return new DiceRoll({
+			objectType: "DiceRoll",
+			gameType: GameType.E20,
+			id: generate(),
+			dice: _dice.toJSON(),
+			rolls: _dice.diceParts.map(dicePart => dicePart.roll().toJSON())
+		});
+	}
+	public static fromCore(core: DiceRollCore): DiceRoll {
+		return new DiceRoll(core);
+	}
+	public static Dice = <typeof baseDice>Dice;
+	//#endregion
+}
+Dice.Roll = <typeof baseDiceRoll>DiceRoll;
+//#endregion
+
+//#region DiceGroup
+type DiceGroupCore = baseDiceGroupCore;
+export class DiceGroup extends baseDiceGroup<DiceGroupCore, Dice, DiceGroupRoll> {
+	//#region static
+	public static create(_dice: Dice[], diceOutputType?: DiceOutputType): DiceGroup {
+		return new DiceGroup({
+			objectType: "DiceGroup",
+			gameType: GameType.E20,
+			id: generate(),
+			critMethodType: undefined,
+			dice: _dice.map<DiceCore>(toJSON),
+			diceOutputType: diceOutputType,
+			diceSecretMethodType: DiceSecretMethodType.Ignore
+		});
+	}
+	public static fromCore(core: DiceGroupCore): DiceGroup {
+		return new DiceGroup(core);
+	}
+	public static fromTokens(tokens: TToken[], diceOutputType?: DiceOutputType): DiceGroup {
+		const skillDicePart = DicePart.fromTokens(tokens);
+		const skillDice = Dice.create([skillDicePart]);
+		const dice = [skillDice];
+
+		if (skillDicePart.sides !== 20) {
+			const d20DicePartCore: DicePartCore = {
+				objectType: "DicePart",
+				gameType: GameType.E20,
+				id: generate(),
+				count: 1,
+				sides: 20,
+				description: "",
+				modifier: 0,
+				noSort: false
+			};
+			if (skillDicePart.hasDropKeep) {
+				d20DicePartCore.count = 2;
+				d20DicePartCore.dropKeep = skillDicePart.dropKeep;
+				delete skillDicePart.toJSON().dropKeep;
+			}
+			const d20DicePart = new DicePart(d20DicePartCore);
+			const d20Dice = Dice.create([d20DicePart]);
+			dice.unshift(d20Dice);
+		}else {
+			if (skillDicePart.hasDropKeep) {
+				skillDicePart.toJSON().count = 2;
+			}
+		}
+
+		const sides = skillDicePart.sides;
+		const diceSides = [2,4,6,8,10,12];
+		if (skillDicePart.hasSpecialiation && sides > 2 && diceSides.includes(sides)) {
+			for (let index = diceSides.indexOf(sides); index--;) {
+				dice.push(Dice.create([new DicePart({
+					objectType: "DicePart",
+					gameType: GameType.E20,
+					id: generate(),
+					count: 1,
+					sides: diceSides[index],
+					description: "",
+					modifier: 0,
+					noSort: false
+				})]));
+			}
+		}
+		return DiceGroup.create(dice, diceOutputType);
+	}
+	public static parse(diceString: string, diceOutputType?: DiceOutputType): DiceGroup {
+		const tokens = Tokenizer.tokenize(diceString, getParsers(), "desc");
+		return DiceGroup.fromTokens(tokens, diceOutputType);
+	}
+	public static Part = <typeof baseDice>Dice;
+	public static Roll: typeof baseDiceGroupRoll;
+	//#endregion
+}
+//#endregion
+
+//#region DiceGroupRoll
+type DiceGroupRollCore = baseDiceGroupRollCore;
+export class DiceGroupRoll extends baseDiceGroupRoll<DiceGroupRollCore, DiceGroup, DiceRoll> {
+	public toString(outputType: DiceOutputType): string;
+	public toString(): string {
+		const d20Roll = this.rolls[0];
+		const baseRoll: DiceRoll | undefined = this.rolls[1];
+		const slicedRolls = this.rolls.slice(1);
+		const highestRoll: DiceRoll | undefined = slicedRolls.reduce((highest, roll) => !highest || roll.total > highest.total ? roll : highest, undefined as DiceRoll | undefined);
+		const maxRoll = slicedRolls.find(roll => (roll.dice.baseDicePart?.sides ?? 0) > 2 && roll.rolls.find(dpRoll => dpRoll.maxCount));
+
+		const description = baseRoll?.dice.baseDicePart?.description ?? d20Roll.dice.baseDicePart?.description;
+		const total = d20Roll.total + (highestRoll?.total ?? 0);
+
+		const test = baseRoll?.dice.test ?? d20Roll.dice.test;
+		let dif = "";
+		let emoji = "";
+		if (test) {
+			if (total >= test.value) {
+				emoji = maxRoll ? "[critical-success]" : "[success]";
+			}else {
+				emoji = d20Roll.isMin ? "[critical-failure]" : "[failure]";
+			}
+			dif = `DIF ${test.value}`;
+		}else if (maxRoll) {
+			emoji = "[critical-success]";
+		}else if (d20Roll.isMin) {
+			emoji = "[critical-failure]";
+		}
+
+		const parts = this.rolls.map((roll, index) => {
+			const out = roll.toString(DiceOutputType.M).split(/⟵/)[1].split(/\bdif\b/)[0].trim();
+			if (index && roll !== highestRoll) {
+				return `<s>${out}</s>`;
+			}
+			return out;
+		});
+
+		const desc = description ? `\`${description}\`` : "";
+		return `${emoji} <b>${total}</b> ${dif} ${desc} ⟵ ${parts.join("; ")}`.replace(/\s+/g, " ");
+	}
+	public static create(diceGroup: DiceGroup): DiceGroupRoll {
+		return new DiceGroupRoll({
+			objectType: "DiceGroupRoll",
+			gameType: GameType.E20,
+			id: generate(),
+			diceGroup: diceGroup.toJSON(),
+			rolls: diceGroup.dice.map(_dice => _dice.roll().toJSON())
+		});
+	}
+	public static fromCore(core: DiceGroupRollCore): DiceGroupRoll {
+		return new DiceGroupRoll(core);
+	}
+	public static Dice = <typeof baseDiceGroup>DiceGroup;
+}
+DiceGroup.Roll = <typeof baseDiceGroupRoll>DiceGroupRoll;
+//#endregion

--- a/src/sage-dice/dice/quest/index.ts
+++ b/src/sage-dice/dice/quest/index.ts
@@ -1,7 +1,6 @@
 //#region imports
 
 import type { OrNull, TParsers, TToken } from "../../../sage-utils";
-import utils from "../../../sage-utils";
 import type {
 	TDiceLiteral,
 	TTestData
@@ -24,6 +23,9 @@ import {
 	DiceGroupRoll as baseDiceGroupRoll, DicePart as baseDicePart,
 	DicePartRoll as baseDicePartRoll, DiceRoll as baseDiceRoll
 } from "../base";
+import { generate } from "../../../sage-utils/utils/UuidUtils";
+import { toJSON } from "../../../sage-utils/utils/ClassUtils";
+import { Tokenizer } from "../../../sage-utils/utils/StringUtils";
 
 //#endregion
 
@@ -36,8 +38,8 @@ function getParsers(): TParsers {
 }
 function reduceTokenToDicePartCore<T extends DicePartCore>(core: T, token: TToken): T {
 	if (token.type === "dice") {
-		core.sides = 1;
-		core.count = 20;
+		core.count = 1;
+		core.sides = 20;
 	}else if (token.type === "target") {
 		core.target = { type:TargetType.VS, value:+(token.matches || [])[1] || 0 };
 	}else {
@@ -97,7 +99,7 @@ export class DicePart extends baseDicePart<DicePartCore, DicePartRoll> {
 		return new DicePart({
 			objectType: "DicePart",
 			gameType: GameType.Quest,
-			id: utils.UuidUtils.generate(),
+			id: generate(),
 
 			count: 1,
 			description: cleanDescription(description),
@@ -130,7 +132,7 @@ export class DicePartRoll extends baseDicePartRoll<DicePartRollCore, DicePart> {
 		return new DicePartRoll({
 			objectType: "DicePartRoll",
 			gameType: GameType.Quest,
-			id: utils.UuidUtils.generate(),
+			id: generate(),
 			dice: dicePart.toJSON(),
 			rolls: rollDice(dicePart.count, dicePart.sides)
 		});
@@ -152,8 +154,8 @@ export class Dice extends baseDice<DiceCore, DicePart, DiceRoll> {
 		return new Dice({
 			objectType: "Dice",
 			gameType: GameType.Quest,
-			id: utils.UuidUtils.generate(),
-			diceParts: diceParts.map<DicePartCore>(utils.ClassUtils.toJSON)
+			id: generate(),
+			diceParts: diceParts.map<DicePartCore>(toJSON)
 		});
 	}
 	public static fromCore(core: DiceCore): Dice {
@@ -187,7 +189,7 @@ export class DiceRoll extends baseDiceRoll<DiceRollCore, Dice, DicePartRoll> {
 		return new DiceRoll({
 			objectType: "DiceRoll",
 			gameType: GameType.Quest,
-			id: utils.UuidUtils.generate(),
+			id: generate(),
 			dice: _dice.toJSON(),
 			rolls: _dice.diceParts.map(dicePart => dicePart.roll().toJSON())
 		});
@@ -209,9 +211,9 @@ export class DiceGroup extends baseDiceGroup<DiceGroupCore, Dice, DiceGroupRoll>
 		return new DiceGroup({
 			objectType: "DiceGroup",
 			gameType: GameType.Quest,
-			id: utils.UuidUtils.generate(),
+			id: generate(),
 			critMethodType: undefined,
-			dice: _dice.map<DiceCore>(utils.ClassUtils.toJSON),
+			dice: _dice.map<DiceCore>(toJSON),
 			diceOutputType: diceOutputType,
 			diceSecretMethodType: DiceSecretMethodType.Ignore
 		});
@@ -223,7 +225,7 @@ export class DiceGroup extends baseDiceGroup<DiceGroupCore, Dice, DiceGroupRoll>
 		return DiceGroup.create([Dice.create([DicePart.fromTokens(tokens)])], diceOutputType);
 	}
 	public static parse(diceString: string, diceOutputType?: DiceOutputType): DiceGroup {
-		const tokens = utils.StringUtils.Tokenizer.tokenize(diceString, getParsers(), "desc");
+		const tokens = Tokenizer.tokenize(diceString, getParsers(), "desc");
 		return DiceGroup.fromTokens(tokens, diceOutputType);
 	}
 	public static Part = <typeof baseDice>Dice;
@@ -243,7 +245,7 @@ export class DiceGroupRoll extends baseDiceGroupRoll<DiceGroupRollCore, DiceGrou
 		return new DiceGroupRoll({
 			objectType: "DiceGroupRoll",
 			gameType: GameType.Quest,
-			id: utils.UuidUtils.generate(),
+			id: generate(),
 			diceGroup: diceGroup.toJSON(),
 			rolls: diceGroup.dice.map(_dice => _dice.roll().toJSON())
 		});

--- a/src/sage-lib/sage/commands/dialog.ts
+++ b/src/sage-lib/sage/commands/dialog.ts
@@ -603,7 +603,7 @@ async function isDelete(sageReaction: SageReaction): Promise<TCommand | null> {
 	}
 
 	const userDid = sageReaction.user.id;
-	if (game && !game.hasUser(userDid)) {
+	if (game && !(await game.hasUser(userDid))) {
 		return null;
 	}
 
@@ -646,13 +646,13 @@ async function isPin(sageReaction: SageReaction): Promise<TCommand | null> {
 	}
 
 	const game = sageReaction.caches.game;
-	if (!game?.hasUser(sageReaction.user.id)) {
+	if (!(await game?.hasUser(sageReaction.user.id))) {
 		return null;
 	}
 
 	const isBotOrWebhook = await isAuthorBotOrWebhook(sageReaction);
 	const messageAuthorDid = message.author?.id;
-	if (!isBotOrWebhook && !game.hasUser(messageAuthorDid)) {
+	if (!isBotOrWebhook && !(await game?.hasUser(messageAuthorDid))) {
 		return null;
 	}
 

--- a/src/sage-lib/sage/commands/pathbuilder.ts
+++ b/src/sage-lib/sage/commands/pathbuilder.ts
@@ -1,89 +1,52 @@
 import * as Discord from "discord.js";
 import { PathbuilderCharacter, toModifier } from "../../../sage-pf2e";
-import type { TPathbuilderCharacter, TPathbuilderCharacterCustomFlags, TPathbuilderCharacterOutputType } from "../../../sage-pf2e/model/pc/PathbuilderCharacter";
-import utils, { UUID } from "../../../sage-utils";
+import { getCharacterSections, TCharacterSectionType, TCharacterViewType, TPathbuilderCharacter } from "../../../sage-pf2e/model/pc/PathbuilderCharacter";
+import { isDefined, Optional, UUID } from "../../../sage-utils";
+import { errorReturnFalse, errorReturnNull } from "../../../sage-utils/utils/ConsoleUtils/Catchers";
+import { readJsonFile, writeFile } from "../../../sage-utils/utils/FsUtils";
+import { StringMatcher } from "../../../sage-utils/utils/StringUtils";
 import { registerSlashCommand } from "../../../slash.mjs";
 import type { TSlashCommand } from "../../../types";
 import { DiscordId, DUser, TChannel } from "../../discord";
 import { resolveToEmbeds } from "../../discord/embeds";
 import { registerInteractionListener } from "../../discord/handlers";
-import { discordPromptYesNo } from "../../discord/prompts";
 import type SageCache from "../model/SageCache";
 import type SageInteraction from "../model/SageInteraction";
-import type SageMessage from "../model/SageMessage";
-import { registerAdminCommand } from "./cmd";
+import type User from "../model/User";
+import type { TMacro } from "../model/User";
 import { parseDiceMatches, sendDice } from "./dice";
 
-async function pathbuilder2e(sageMessage: SageMessage): Promise<void> {
-	if (!sageMessage.allowAdmin) {
-		return sageMessage.reactBlock();
+type TLabeledMacro = TMacro & { prefix:string; };
+function getMacros(character: PathbuilderCharacter, macroUser: Optional<User>): TLabeledMacro[] {
+	if (!macroUser) {
+		return [];
 	}
+	const attackMacros = character.getAttackMacros()
+		.map(macro => ({ prefix:"Attack Roll", ...macro }));
 
-	// const showAction = sageMessage.args.find(arg => arg.toLowerCase() === "show");
-	const pinAction = !!sageMessage.args.find(arg => arg.toLowerCase() === "pin");
+	const matcher = new StringMatcher(character.name);
+	const userMacros = macroUser.macros
+		.filter(macro => matcher.matches(macro.category))
+		.map(macro => ({ prefix:"Macro Roll", ...macro }));
 
-	const idArg = sageMessage.args.find(arg => arg.match(/^id=\d+$/i));
-	if (!idArg) {
-		return sageMessage.reactWarn();
-	}
-
-	const pathbuilderId = +idArg.split("=")[1];
-	const flags: TPathbuilderCharacterCustomFlags = { };
-	if (false) {
-		flags._proficiencyWithoutLevel = true;
-		flags._untrainedPenalty = true;
-	}
-	const pathbuilderChar = await PathbuilderCharacter.fetch(pathbuilderId, flags);
-	if (!pathbuilderChar) {
-		console.log(`Failed to fetch Pathbuilder character ${pathbuilderId}!`);
-		return sageMessage.reactWarn();
-	}
-
-	if (sageMessage.args.includes("attach")) {
-		return attachCharacter(sageMessage.caches, sageMessage.message.channel as TChannel, pathbuilderId, pathbuilderChar, pinAction);
-	}
-
-	const messages = await sageMessage.send(`*Pathbuilder2e:${pathbuilderId}*\n` + pathbuilderChar.toHtml());
-	if (pinAction && messages[0]?.pinnable) {
-		await messages[0].pin();
-	}
-
-	if (sageMessage.playerCharacter?.name === pathbuilderChar.name) {
-		const bool = await discordPromptYesNo(sageMessage, `Update ${pathbuilderChar.name}?`);
-		if (bool === true) {
-			const updated = await sageMessage.playerCharacter.update({ pathbuilder:pathbuilderChar.toJSON() });
-			await sageMessage.reactSuccessOrFailure(updated);
-		}
-	}else if (sageMessage.isPlayer) {
-		if (sageMessage.playerCharacter) {
-			const bool = await discordPromptYesNo(sageMessage, `Replace ${sageMessage.playerCharacter.name} with ${pathbuilderChar.name}?`);
-			if (bool === true) {
-				const replaced = await sageMessage.playerCharacter.update({ pathbuilder:pathbuilderChar.toJSON() });
-				await sageMessage.reactSuccessOrFailure(replaced);
-			}
-		}else {
-			const bool = await discordPromptYesNo(sageMessage, `Import ${pathbuilderChar.name}?`);
-			if (bool === true) {
-				const added = await sageMessage.game?.playerCharacters.addCharacter({
-					id: utils.UuidUtils.generate(),
-					pathbuilder: pathbuilderChar.toJSON(),
-					name: pathbuilderChar.name,
-					userDid: sageMessage.sageUser.did
-				});
-				await sageMessage.reactSuccessOrFailure(added !== null);
-			}
-		}
+	return attackMacros.concat(userMacros);
+}
+function setMacroUser(character: PathbuilderCharacter, macroUser: User): void {
+	if (getMacros(character, macroUser).length > 0) {
+		character.setSheetValue("macroUserId", macroUser.id);
+	}else {
+		character.setSheetValue("macroUserId", null);
 	}
 }
 
-async function attachCharacter(sageCache: SageCache, channel: TChannel | DUser, pathbuilderId: number, pathbuilderChar: PathbuilderCharacter, pin: boolean): Promise<void> {
-	const raw = resolveToEmbeds(sageCache, pathbuilderChar.toHtml()).map(e => e.description).join("");
+async function attachCharacter(sageCache: SageCache, channel: TChannel | DUser, pathbuilderId: number, character: PathbuilderCharacter, pin: boolean): Promise<void> {
+	const raw = resolveToEmbeds(sageCache, character.toHtml()).map(e => e.description).join("");
 	const buffer = Buffer.from(raw, "utf-8");
 	const attachment = new Discord.MessageAttachment(buffer, `pathbuilder2e-${pathbuilderId}.txt`);
 	const message = await channel.send({
-		content: `Attaching Pathbuilder2e Character: ${pathbuilderChar.name} (${pathbuilderId})`,
+		content: `Attaching Pathbuilder2e Character: ${character.name} (${pathbuilderId})`,
 		files:[attachment]
-	}).catch(utils.ConsoleUtils.Catchers.errorReturnNull);
+	}).catch(errorReturnNull);
 	if (pin && message?.pinnable) {
 		await message.pin();
 	}
@@ -91,10 +54,10 @@ async function attachCharacter(sageCache: SageCache, channel: TChannel | DUser, 
 }
 
 function saveCharacter(character: PathbuilderCharacter): Promise<boolean> {
-	return utils.FsUtils.writeFile(getPath(character.id), character.toJSON(), true).catch(utils.ConsoleUtils.Catchers.errorReturnFalse);
+	return writeFile(getPath(character.id), character.toJSON(), true).catch(errorReturnFalse);
 }
 async function loadCharacter(characterId: UUID): Promise<PathbuilderCharacter | null> {
-	const core = await utils.FsUtils.readJsonFile<TPathbuilderCharacter>(getPath(characterId)).catch(utils.ConsoleUtils.Catchers.errorReturnNull);
+	const core = await readJsonFile<TPathbuilderCharacter>(getPath(characterId)).catch(errorReturnNull);
 	return core ? new PathbuilderCharacter(core) : null;
 }
 function getPath(pathbuilderCharId: string): string {
@@ -102,16 +65,17 @@ function getPath(pathbuilderCharId: string): string {
 }
 
 async function postCharacter(sageCache: SageCache, channel: TChannel, character: PathbuilderCharacter, pin: boolean): Promise<void> {
+	setMacroUser(character, sageCache.user);
 	const saved = await saveCharacter(character);
 	if (saved) {
-		const output = prepareOutput(sageCache, character);
-		const message = await channel.send(output).catch(utils.ConsoleUtils.Catchers.errorReturnNull);
+		const output = prepareOutput(sageCache, character, sageCache.user);
+		const message = await channel.send(output).catch(errorReturnNull);
 		if (pin && message?.pinnable) {
 			await message.pin();
 		}
 	}else {
 		const output = { embeds:resolveToEmbeds(sageCache, character.toHtml()) };
-		const message = await channel.send(output).catch(utils.ConsoleUtils.Catchers.errorReturnNull);
+		const message = await channel.send(output).catch(errorReturnNull);
 		if (pin && message?.pinnable) {
 			await message.pin();
 		}
@@ -119,30 +83,52 @@ async function postCharacter(sageCache: SageCache, channel: TChannel, character:
 }
 
 async function updateSheet(sageInteraction: SageInteraction, character: PathbuilderCharacter) {
-	const output = prepareOutput(sageInteraction.caches, character);
+	const macroUser = await sageInteraction.caches.users.getById(character.getSheetValue("macroUserId"));
+	const output = prepareOutput(sageInteraction.caches, character, macroUser);
 	const message = sageInteraction.interaction.message as Discord.Message;
 	await message.edit(output);
 }
 
+function getActiveSections(character: PathbuilderCharacter): TCharacterSectionType[] {
+	const activeView = character.getSheetValue<TCharacterViewType>("activeView");
+	const activeSections = character.getSheetValue<TCharacterSectionType[]>("activeSections");
+	return getCharacterSections(activeView) ?? activeSections ?? getCharacterSections("Combat") ?? [];
+}
 function createViewSelectRow(character: PathbuilderCharacter): Discord.MessageActionRow {
 	const selectMenu = new Discord.MessageSelectMenu();
 	selectMenu.setCustomId(`${character.id}|View`);
-	selectMenu.setPlaceholder("Select Character View");
+	selectMenu.setPlaceholder("Character Sheet Sections");
+	selectMenu.setMinValues(1);
 
-	const activeView = character.getSheetValue("activeView");
-	const validOutputTypes = character.getValidOutputTypes();
-	validOutputTypes.forEach((outputType, index) =>
+	const activeSections = getActiveSections(character);
+
+	const validSectionTypes = character.getValidSectionsTypes();
+	validSectionTypes.sort();
+	validSectionTypes.forEach(sectionType => {
 		selectMenu.addOptions({
-			label: `Character View: ${outputType}`,
-			value: outputType,
-			default: outputType === activeView || (!activeView && !index)
-		})
-	);
+			label: sectionType,
+			value: sectionType,
+			default: activeSections.includes(sectionType)
+		});
+	});
+
+	const validViewTypes = character.getValidViewTypes();
+	validViewTypes.forEach(view => {
+		const sections = getCharacterSections(view) ?? [];
+		sections.sort();
+		selectMenu.addOptions({
+			label: `Character View: ${view}`,
+			value: sections.join(","),
+			description: view === "All" ? "All Sections" : sections.join(", "),
+			default: view === "All" && activeSections.includes("All")
+		});
+	});
 
 	return new Discord.MessageActionRow().addComponents(selectMenu);
 }
 
 const skills = "Perception,Acrobatics,Arcana,Athletics,Crafting,Deception,Diplomacy,Intimidation,Medicine,Nature,Occultism,Performance,Religion,Society,Stealth,Survival,Thievery".split(",");
+const saves = ["Fortitude", "Reflex", "Will"];
 
 function createExplorationSelectRow(character: PathbuilderCharacter): Discord.MessageActionRow {
 	const selectMenu = new Discord.MessageSelectMenu();
@@ -169,14 +155,37 @@ function createSkillSelectRow(character: PathbuilderCharacter): Discord.MessageA
 
 	const activeSkill = character.getSheetValue("activeSkill");
 	const lores = character.lores.map(lore => lore[0]);
-	const skillsAndLores = skills.concat(lores);
-	skillsAndLores.forEach(skill => {
+	const savesSkillsAndLores = saves.concat(skills, lores);
+	savesSkillsAndLores.forEach(skill => {
+		const labelPrefix = saves.includes(skill) ? "Save" : "Skill";
 		const skillAndMod = character.getProficiencyAndMod(skill);
 		selectMenu.addOptions({
-			label: `Skill Roll: ${skill}${lores.includes(skill) ? " Lore" : ""} ${toModifier(skillAndMod[1])} (${skillAndMod[0]})`,
+			label: `${labelPrefix} Roll: ${skill}${lores.includes(skill) ? " Lore" : ""} ${toModifier(skillAndMod[1])} (${skillAndMod[0]})`,
 			value: skill,
 			default: skill === activeSkill || (!activeSkill && skill === "Perception")
 		});
+	});
+
+	return new Discord.MessageActionRow().addComponents(selectMenu);
+}
+
+function createMacroSelectRow(character: PathbuilderCharacter, macros: TLabeledMacro[]): Discord.MessageActionRow {
+	const selectMenu = new Discord.MessageSelectMenu();
+	selectMenu.setCustomId(`${character.id}|Macro`);
+	selectMenu.setPlaceholder("Select a Macro to Roll");
+
+	const activeMacro = character.getSheetValue("activeMacro");
+	macros.forEach(macro => {
+		selectMenu.addOptions({
+			label: `${macro.prefix}: ${macro.name}`,
+			value: macro.name,
+			default: macro.name === activeMacro
+		});
+	});
+	selectMenu.addOptions({
+		label: `Refresh Character Macro List`,
+		value: `REFRESH`,
+		default: false
 	});
 
 	return new Discord.MessageActionRow().addComponents(selectMenu);
@@ -190,62 +199,84 @@ function createButton(customId: string, label: string, style: Discord.MessageBut
 	return button;
 }
 
-function createRollButtonRow(character: PathbuilderCharacter): Discord.MessageActionRow {
-	// const activeSkill = character.getSheetValue<string>("activeSkill") ?? "Perception";
-	// const lores = character.lores.map(lore => lore[0]);
-	// const skill = lores.includes(activeSkill) ? `${activeSkill} Lore` : activeSkill;
-
+function createRollButtonRow(character: PathbuilderCharacter, macros: TMacro[]): Discord.MessageActionRow {
 	const rollButton = createButton(`${character.id}|Roll`, `Roll Check`, "PRIMARY");
 	const rollSecretButton = createButton(`${character.id}|Secret`, `Roll Secret Check`, "PRIMARY");
 	const rollInitButton = createButton(`${character.id}|Init`, `Roll Initiative`, "PRIMARY");
-	return new Discord.MessageActionRow().addComponents(rollButton, rollSecretButton, rollInitButton);
+	const macroButton = createButton(`${character.id}|MacroRoll`, macros.length > 0 ? `Roll Macro` : `Load Macros`, "PRIMARY");
+	return new Discord.MessageActionRow().addComponents(rollButton, rollSecretButton, rollInitButton, macroButton);
 }
 
-function createComponents(character: PathbuilderCharacter): Discord.MessageActionRow[] {
+function createComponents(character: PathbuilderCharacter, macroUser: Optional<User>): Discord.MessageActionRow[] {
+	const macros = getMacros(character, macroUser);
 	return [
 		createViewSelectRow(character),
 		createExplorationSelectRow(character),
 		createSkillSelectRow(character),
-		createRollButtonRow(character)
-	];
+		macros.length > 0 ? createMacroSelectRow(character, macros) : undefined,
+		createRollButtonRow(character, macros)
+	].filter(isDefined);
 }
 
 type TOutput = { embeds:Discord.MessageEmbed[], components:Discord.MessageActionRow[] };
-function prepareOutput(sageCache: SageCache, character: PathbuilderCharacter): TOutput {
-	const activeView = character.getSheetValue<TPathbuilderCharacterOutputType>("activeView");
-	const defaultView = character.getValidOutputTypes()[0];
-	const outputType = activeView ?? defaultView;
-	const embeds = resolveToEmbeds(sageCache, character.toHtml(outputType));
-	const components = createComponents(character);
+function prepareOutput(sageCache: SageCache, character: PathbuilderCharacter, macroUser: Optional<User>): TOutput {
+	const embeds = resolveToEmbeds(sageCache, character.toHtml(getActiveSections(character)));
+	const components = createComponents(character, macroUser);
 	return { embeds, components };
 }
 
 //#region button command
 
-const uuidActionRegex = /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})\|(?:View|Exploration|Skill|Roll|Secret|Init)$/i;
+const uuidActionRegex = /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})\|(?:View|Exploration|Skill|Macro|Roll|Secret|Init|MacroRoll)$/i;
 
 function sheetTester(sageInteraction: SageInteraction): boolean {
 	return uuidActionRegex.test(sageInteraction.interaction.customId);
 }
 
-async function viewHandler(sageInteraction: SageInteraction, character: PathbuilderCharacter): Promise<void> {
-	const activeView = (sageInteraction.interaction as Discord.SelectMenuInteraction).values[0];
-	character.setSheetValue("activeView", activeView);
+async function viewHandler(sageInteraction: SageInteraction<Discord.SelectMenuInteraction>, character: PathbuilderCharacter): Promise<void> {
+	const values = sageInteraction.interaction.values;
+	const activeSections: string[] = [];
+	if (values.includes("All")) {
+		activeSections.push("All");
+	}else {
+		const activeView = values.find(value => value.includes(","));
+		if (activeView) {
+			activeSections.push(...activeView.split(","));
+		}else {
+			activeSections.push(...values);
+		}
+	}
+	character.setSheetValue("activeView", undefined);
+	character.setSheetValue("activeSections", activeSections);
 	await saveCharacter(character);
 	return updateSheet(sageInteraction, character);
 }
+
 async function explorationHandler(sageInteraction: SageInteraction, character: PathbuilderCharacter): Promise<void> {
 	const activeExploration = (sageInteraction.interaction as Discord.SelectMenuInteraction).values[0];
 	character.setSheetValue("activeExploration", activeExploration);
 	await saveCharacter(character);
 	return updateSheet(sageInteraction, character);
 }
-async function skillHandler(sageInteraction: SageInteraction, character: PathbuilderCharacter): Promise<void> {
-	const activeSkill = (sageInteraction.interaction as Discord.SelectMenuInteraction).values[0];
+
+async function skillHandler(sageInteraction: SageInteraction<Discord.SelectMenuInteraction>, character: PathbuilderCharacter): Promise<void> {
+	const activeSkill = sageInteraction.interaction.values[0];
 	character.setSheetValue("activeSkill", activeSkill);
 	await saveCharacter(character);
 	return updateSheet(sageInteraction, character);
 }
+
+async function macroHandler(sageInteraction: SageInteraction, character: PathbuilderCharacter): Promise<void> {
+	const activeMacro = sageInteraction.interaction.values[0];
+	if (activeMacro === "REFRESH") {
+		setMacroUser(character, sageInteraction.sageUser);
+	}else {
+		character.setSheetValue("activeMacro", activeMacro);
+	}
+	await saveCharacter(character);
+	return updateSheet(sageInteraction, character);
+}
+
 function getInitSkill(character: PathbuilderCharacter): string {
 	const activeExploration = character.getSheetValue("activeExploration");
 	switch(activeExploration) {
@@ -268,20 +299,43 @@ async function rollHandler(sageInteraction: SageInteraction<Discord.ButtonIntera
 		await sageInteraction.interaction.channel?.send(`${DiscordId.toUserMention(sageInteraction.user.id)} *Secret Dice sent to the GM* 🎲`);
 	}
 }
+
+async function macroRollHandler(sageInteraction: SageInteraction, character: PathbuilderCharacter): Promise<void> {
+	const macroUser = await sageInteraction.caches.users.getById(character.getSheetValue("macroUserId"));
+	const macros = getMacros(character, macroUser);
+	if (!macros.length) {
+		setMacroUser(character, sageInteraction.sageUser);
+		await saveCharacter(character);
+		await updateSheet(sageInteraction, character);
+	}else {
+		const activeMacro = character.getSheetValue("activeMacro");
+		const macro = macros.find(m => m.name === activeMacro);
+		if (macro) {
+			const matches = parseDiceMatches(sageInteraction, macro.dice.replace(/\{.*?\}/g, match => match.slice(1,-1).split(":")[1] ?? ""));
+			const output = matches.map(match => match.output).flat();
+			await sendDice(sageInteraction, output);
+		}else {
+			sageInteraction.send("Invalid Macro!");
+		}
+	}
+}
+
 async function sheetHandler(sageInteraction: SageInteraction): Promise<void> {
 	await sageInteraction.interaction.deferUpdate();
 	const actionParts = sageInteraction.interaction.customId.split("|");
 	const characterId = actionParts[0] as UUID;
 	const character = await loadCharacter(characterId);
 	if (character) {
-		const command = actionParts[1] as "View" | "Exploration" | "Skill" | "Roll" | "Secret" | "Init";
+		const command = actionParts[1] as "View" | "Exploration" | "Skill" | "Macro" | "Roll" | "Secret" | "Init" | "MacroRoll";
 		switch(command) {
 			case "View": return viewHandler(sageInteraction, character);
 			case "Exploration": return explorationHandler(sageInteraction, character);
 			case "Skill": return skillHandler(sageInteraction, character);
+			case "Macro": return macroHandler(sageInteraction, character);
 			case "Roll": return rollHandler(sageInteraction, character, false);
 			case "Secret": return rollHandler(sageInteraction, character, true);
 			case "Init": return rollHandler(sageInteraction, character, false, true);
+			case "MacroRoll": return macroRollHandler(sageInteraction, character);
 		}
 	}
 	return Promise.resolve();
@@ -295,15 +349,17 @@ function slashTester(sageInteraction: SageInteraction): boolean {
 	return sageInteraction.isCommand("import");
 }
 
+const pb2eId = "pathbuilder2e-id";
+
 async function slashHandler(sageInteraction: SageInteraction): Promise<void> {
-	if (sageInteraction.hasNumber("pathbuilder2e-id")) {
+	if (sageInteraction.hasNumber(pb2eId)) {
 		return slashHandlerPathbuilder2e(sageInteraction);
 	}
 	return sageInteraction.reply(`Sorry, unable to import your character at this time.`, true);
 }
 
 async function slashHandlerPathbuilder2e(sageInteraction: SageInteraction): Promise<void> {
-	const pathbuilderId = sageInteraction.getNumber("pathbuilder2e-id", true);
+	const pathbuilderId = sageInteraction.getNumber(pb2eId, true);
 	await sageInteraction.reply(`Fetching Pathbuilder 2e character using 'Export JSON' id: ${pathbuilderId}`, true);
 
 	const pathbuilderChar = await PathbuilderCharacter.fetch(pathbuilderId, { });
@@ -328,7 +384,7 @@ function importCommand(): TSlashCommand {
 		name: "Import",
 		description: "Import a character to Sage",
 		options: [
-			{ name:"pathbuilder2e-id", description:"Import from Pathbuilder 2e using 'Export to JSON'", isNumber:true },
+			{ name:pb2eId, description:"Import from Pathbuilder 2e using 'Export to JSON'", isNumber:true },
 			{ name:"attach", description:"Attach as a Markdown formatted .txt", isBoolean:true },
 			{ name:"pin", description:"Pin character", isBoolean:true }
 		]
@@ -339,7 +395,6 @@ function importCommand(): TSlashCommand {
 //#endregion
 
 export function registerCommandHandlers(): void {
-	registerAdminCommand(pathbuilder2e, "pathbuilder2e");
 	registerInteractionListener(slashTester, slashHandler);
 	registerInteractionListener(sheetTester, sheetHandler);
 }

--- a/src/sage-lib/sage/model/ActiveBot.ts
+++ b/src/sage-lib/sage/model/ActiveBot.ts
@@ -102,6 +102,13 @@ export default class ActiveBot extends Bot implements IClientEventHandler {
 	}
 
 	onClientReady(): void {
+		this.client.user?.setPresence({
+			status: "online"
+		});
+		this.client.user?.setActivity("rpgsage.io; /sage help", {
+			type: "PLAYING"
+		});
+
 		SageCache.fromClient(this.client).then(sageCache => {
 			this.sageCache = sageCache;
 			ActiveBot.active = this;

--- a/src/sage-lib/sage/model/SageInteraction.ts
+++ b/src/sage-lib/sage/model/SageInteraction.ts
@@ -8,6 +8,7 @@ import { resolveToEmbeds } from "../../discord/embeds";
 import { send } from "../../discord/messages";
 import { DicePostType } from "../commands/dice";
 import type { IChannel } from "../repo/base/IdRepository";
+import { GameRoleType } from "./Game";
 import type GameCharacter from "./GameCharacter";
 import type { ColorType, IHasColorsCore } from "./HasColorsCore";
 import HasSageCache, { HasSageCacheCore } from "./HasSageCache";
@@ -16,6 +17,8 @@ import SageCache from "./SageCache";
 interface SageInteractionCore extends HasSageCacheCore {
 	interaction: DInteraction;
 	type: InteractionType;
+	isGameMaster?: boolean;
+	isPlayer?: boolean;
 }
 
 export default class SageInteraction<T extends DInteraction = any>
@@ -233,19 +236,14 @@ export default class SageInteraction<T extends DInteraction = any>
 		return this.cache.get("gameType", () => this.game?.gameType ?? this.serverChannel?.defaultGameType ?? this.server?.defaultGameType ?? GameType.None);
 	}
 
-	/** Is there a game and is the author a GameMaster */
-	public get isGameMaster(): boolean {
-		return this.cache.get("isGameMaster", () => (this.user.id && this.game?.hasGameMaster(this.user.id)) === true);
-	}
+	public get isGameMaster() { return this.core.isGameMaster === true; }
+	public set isGameMaster(bool: boolean) { this.core.isGameMaster = bool === true; }
+	public get isPlayer() { return this.core.isPlayer === true; }
+	public set isPlayer(bool: boolean) { this.core.isPlayer = bool === true; }
 
-	/** Is there a game and is the author a Player */
-	public get isPlayer(): boolean {
-		return this.cache.get("isPlayer", () => (this.user.id && this.game?.hasPlayer(this.user.id)) === true);
-	}
-
-	/** Get the PlayerCharacter if there a game and the author is a Player */
+	/** Get the PlayerCharacter if there a game and the actor has a PlayerCharacter OR the actor has a PlayerCharacter set to use this channel with AutoChannel */
 	public get playerCharacter(): GameCharacter | undefined {
-		return this.cache.get("playerCharacter", () => this.user.id && this.isPlayer ? this.game?.playerCharacters.findByUser(this.user.id) ?? undefined : undefined);
+		return this.cache.get("playerCharacter", () => this.game?.playerCharacters.findByUser(this.sageUser.did) ?? this.sageUser.playerCharacters.find(pc => pc.hasAutoChannel(this.channel?.did!)) ?? undefined);
 	}
 
 	public get critMethodType(): CritMethodType {
@@ -291,11 +289,14 @@ export default class SageInteraction<T extends DInteraction = any>
 	public static async fromInteraction<T extends DInteraction>(interaction: T): Promise<SageInteraction<T>> {
 		const caches = await SageCache.fromInteraction(interaction);
 		const type = InteractionType.Unknown;
-		return new SageInteraction({
+		const sageInteraction = new SageInteraction({
 			caches,
 			interaction,
 			type
 		});
+		sageInteraction.isGameMaster = await sageInteraction.game?.hasUser(interaction.user.id, GameRoleType.GameMaster) ?? false;
+		sageInteraction.isPlayer = await sageInteraction.game?.hasUser(interaction.user.id, GameRoleType.Player) ?? false;
+		return sageInteraction;
 	}
 
 }

--- a/src/sage-lib/sage/model/SageMessageArgsManager.ts
+++ b/src/sage-lib/sage/model/SageMessageArgsManager.ts
@@ -74,7 +74,7 @@ function removeAndReturnCritMethodType(args: string[]): Optional<CritMethodType>
 
 /** /^(diceoutput)=(XXS|XS|S|M|XXL|XL|L|UNSET)?$/i; returns null to unset */
 function removeAndReturnDiceOutputType(args: string[]): Optional<DiceOutputType> {
-	const regex = /^(diceoutput)=(XXS|XS|S|M|XXL|XL|L|UNSET)?$/i;
+	const regex = /^(diceoutput)=(XXS|XS|S|M|XXL|XL|L|ROLLEM|UNSET)?$/i;
 	for (const arg of args) {
 		const match = arg.match(regex);
 		if (match) {
@@ -133,7 +133,7 @@ function removeAndReturnDiceSecretMethodType(args: string[]): Optional<DiceSecre
 
 /** /^(game)=(PF1E|PF1|PF2E|PF2|PF|SF1E|SF1|SF|DND5E|5E|QUEST|NONE)?$/i */
 function removeAndReturnGameType(args: string[]): GameType | undefined {
-	const regex = /^(game)=(PF1E|PF1|PF2E|PF2|PF|SF1E|SF1|SF|DND5E|5E|QUEST|NONE)?$/i;
+	const regex = /^(game)=(ESSENCE20|ESS20|E20|PF1E|PF1|PF2E|PF2|PF|SF1E|SF1|SF|DND5E|5E|QUEST|NONE)?$/i;
 	for (const arg of args) {
 		const match = arg.match(regex);
 		if (match) {

--- a/src/sage-pf2e/model/pc/SavingThrows.ts
+++ b/src/sage-pf2e/model/pc/SavingThrows.ts
@@ -79,7 +79,7 @@ class PbcSavingThrows extends SavingThrows {
 
 	public getSavingThrow(savingThrow: TSavingThrow, ability: TAbility): Check {
 		const check = new Check(this.pbc, savingThrow);
-		check.level = this.pbc.levelProficiencyMod;
+		check.level = this.pbc.getLevelMod(true);
 		check.setAbility(ability);
 		check.addProficiency(savingThrow);
 		if (this.pbc.resilientBonus) {


### PR DESCRIPTION
* can toggle dice pings in games
can use named args in macros
related minor fixes

* rollem implementation

* bot status

* pathbuilder level fix

* parsing/notes tweaks

* isD20 check
support for +/- on 2d20 for keep/drop

* bug fix

* update for base improvements

* initial 5e offering

* initial essence20 code

* fixes non attack roll bug

* e20 totals, grades, toString
signToDropKeep fix
import cleanup

* crit fail fix

* base min/max fix
essence crit logic fix

* macro namedArg fix
macro plus/minus fix

* skill dice tier fix

* fixed d20 checks

* channel set path
- makes sure a game exists before trying to use it

* orphan game channel fix

* e20 crit fix for 2d8 and 3d6

* presence/activity

* updated help

* rollem output fix

* rollem quote fix

* pathbuilder macros

* Added Saves to Checks

* fixes player role issue