### PR TITLE
Nested stats

### DIFF
--- a/src/sage-lib/sage/commands/dice.ts
+++ b/src/sage-lib/sage/commands/dice.ts
@@ -67,59 +67,63 @@ type ReplaceStatsArgs = {
 	encounters?: EncounterManager;
 };
 function replaceStats(diceString: string, args: ReplaceStatsArgs, stack: string[] = []): string {
-	const replaced = diceString.replace(new RegExp(args.statRegex, "gi"), match => {
-		const [_, name, stat, defaultValue] = args.statRegex.exec(match) ?? [];
+	let replaced = diceString;
+	while (args.statRegex.test(replaced)) {
+		replaced = replaced.replace(new RegExp(args.statRegex, "gi"), match => {
+			const [_, name, stat, defaultValue] = args.statRegex.exec(match) ?? [];
 
-		// check stack for recursion
-		const stackValue = `${name}::${stat}`.toLowerCase();
-		if (stack.includes(stackValue)) {
-			return "`" + match + "`";
-		}
+			// check stack for recursion
+			const stackValue = `${name}::${stat}`.toLowerCase();
+			if (stack.includes(stackValue)) {
+				return "`" + match + "`";
+			}
 
-		// get character
-		let char: GameCharacter | CharacterShell | null = null;
-		if (name) {
-			const [isPc, isAlt] = args.typeRegex.exec(name) ?? [];
-			if (isPc) {
-				char = args.pc ?? null;
-			}else if (isAlt) {
-				char = args.pc?.companions[0] ?? null;
+			// get character
+			let char: GameCharacter | CharacterShell | null = null;
+			if (name) {
+				const [isPc, isAlt] = args.typeRegex.exec(name) ?? [];
+				if (isPc) {
+					char = args.pc ?? null;
+				}else if (isAlt) {
+					char = args.pc?.companions[0] ?? null;
+				}else {
+					char = args.pcs.findByName(name)
+						?? args.pcs.findCompanionByName(name)
+						?? args.npcs.findByName(name)
+						?? args.npcs.findCompanionByName(name)
+						?? args.encounters?.findActiveChar(name)
+						?? null;
+				}
 			}else {
-				char = args.pcs.findByName(name)
-					?? args.pcs.findCompanionByName(name)
-					?? args.npcs.findByName(name)
-					?? args.npcs.findCompanionByName(name)
-					?? args.encounters?.findActiveChar(name)
-					?? null;
+				char = args.pc ?? null;
 			}
-		}else {
-			char = args.pc ?? null;
-		}
 
-		// get stat
-		const statVal = char?.getStat(stat);
-		const statValue = statVal ?? defaultValue?.trim() ?? "";
-		if (statValue.length) {
-			// check for nested stat block
-			if (args.statRegex.test(statValue)) {
-				return replaceStats(statValue, args, stack.concat([stackValue]));
+			// get stat
+			const statVal = char?.getStat(stat);
+			const statValue = statVal ?? defaultValue?.trim() ?? "";
+			if (statValue.length) {
+				// check for nested stat block
+				if (args.statRegex.test(statValue)) {
+					return replaceStats(statValue, args, stack.concat([stackValue]));
+				}
+				return statValue;
 			}
-			return statValue;
-		}
 
-		// return escaped match
-		return "`" + match + "`";
-	});
-
-	// ensure any math is handled
-	return doStatMath(replaced);
+			// return escaped match
+			return "`" + match + "`";
+		});
+		// ensure any math is handled
+		return doStatMath(replaced);
+	}
+	// return updated value
+	return replaced;
 }
 function parseDiscordDice(sageMessage: TInteraction, diceString: string, overrides?: TDiscordDiceParseOptions): DiscordDice | null {
 	if (!diceString) {
 		return null;
 	}
 
-	const statRegex = /\{([\w ]+|"[\w ]+"):{2}([^:}]+)(?::([^}]+))?\}/i;
+	const statRegex = /\{([\w ]+|"[\w ]+"):{2}([^:{}}]+)(?::([^}]+))?\}/i;
 	if (statRegex.test(diceString)) {
 		const { game, isGameMaster, isPlayer } = sageMessage;
 		if (!game || isGameMaster || isPlayer) {

--- a/src/sage-lib/sage/commands/dice.ts
+++ b/src/sage-lib/sage/commands/dice.ts
@@ -123,7 +123,7 @@ function parseDiscordDice(sageMessage: TInteraction, diceString: string, overrid
 		return null;
 	}
 
-	const statRegex = /(?<!`)\{([\w ]+|"[\w ]+"):{2}([^:{}}]+)(?::([^}]+))?\}(?!`)/i;
+	const statRegex = /(?<!`)\{([\w ]+|"[\w ]+"):{2}([^:{}}]+)(?::([^{}]+))?\}(?!`)/i;
 	if (statRegex.test(diceString)) {
 		const { game, isGameMaster, isPlayer } = sageMessage;
 		if (!game || isGameMaster || isPlayer) {

--- a/src/sage-lib/sage/commands/dice.ts
+++ b/src/sage-lib/sage/commands/dice.ts
@@ -123,7 +123,7 @@ function parseDiscordDice(sageMessage: TInteraction, diceString: string, overrid
 		return null;
 	}
 
-	const statRegex = /\{([\w ]+|"[\w ]+"):{2}([^:{}}]+)(?::([^}]+))?\}/i;
+	const statRegex = /(?<!`)\{([\w ]+|"[\w ]+"):{2}([^:{}}]+)(?::([^}]+))?\}(?!`)/i;
 	if (statRegex.test(diceString)) {
 		const { game, isGameMaster, isPlayer } = sageMessage;
 		if (!game || isGameMaster || isPlayer) {


### PR DESCRIPTION
Changes the stats regex to grab only the most deeply nested (and unescaped) stats and changes the replaceStats function to loop as long as it continues finding stats.